### PR TITLE
Support current devnet behavior without hiding semantic drift

### DIFF
--- a/docs/devnet-compatibility.md
+++ b/docs/devnet-compatibility.md
@@ -1,0 +1,70 @@
+# Devnet Compatibility Report
+
+Last updated: 2026-03-18
+
+## Scope
+
+This report documents stable behavioral drift between the current local SDK/source expectations and the AgenC program deployed on Solana devnet.
+
+The drift was reproduced by running the deep devnet integration harness with funded creator and worker wallets:
+
+```bash
+CREATOR_WALLET=/path/to/creator.json \
+WORKER_WALLET=/path/to/worker.json \
+npm run test:devnet:deep
+```
+
+The deep harness lives at `/Users/pchmirenko/tmp/agenc-sdk-review-20260318/scripts/devnet-integration-deep.mjs`.
+
+## Stable Drift Map
+
+| Scenario | Expected Local Error | Observed Devnet Error | Notes |
+| --- | --- | --- | --- |
+| Register agent below minimum stake | `InsufficientStake` | `InsufficientFunds` | Reproduced across reruns. Suggests the deployed devnet program or error mapping does not match the current local expectation for low-stake registration. |
+| Create task with past deadline | `InvalidInput` | `UpdateTooFrequent` | Even after waiting past the configured task creation cooldown, devnet still returns a cooldown-style error for this case before the expected deadline validation result. |
+| Creator self-claims own task | `SelfTaskNotAllowed` | `ProposalUnauthorizedCancel` | Behavior rejects the action, but the decoded error name is unrelated to task claiming. This points to error-table drift. |
+| Complete task without an initialized claim | `NotClaimed` | `AccountNotInitialized` | Devnet rejects the action at the missing claim-account layer instead of surfacing the higher-level semantic error expected by the current source. |
+| Cancel task after successful completion | `InvalidStatusTransition` or `TaskCannotBeCancelled` | `AccountNotInitialized` | The action fails because the escrow account is already gone. The behavioral outcome is acceptable, but the surfaced error differs from the current local expectation. |
+
+## Checks That Still Align
+
+These scenarios matched the current SDK/source expectations on devnet:
+
+- Claim with insufficient capabilities returns `InsufficientCapabilities`
+- Deregistering a worker with an active task returns `AgentHasActiveTasks`
+- Public happy path `register -> create -> claim -> complete` succeeds
+- Final on-chain task state verifies as `Completed`
+- Cleanup deregistration succeeds after task completion
+
+## Harness Behavior
+
+The deep devnet harness supports two modes:
+
+- `compat`
+  - Accepts the known devnet drift listed above
+  - Logs each drift explicitly
+  - Exits successfully if only known drift is observed
+
+- `strict`
+  - Fails on any semantic drift, including the known mappings above
+  - Useful for checking whether devnet has caught up with current local expectations
+
+Recommended commands:
+
+```bash
+# Developer-friendly: passes while still logging the known drift
+npm run test:devnet:deep
+
+# Strict: fails until devnet behavior matches local expectations
+npm run test:devnet:deep:strict
+```
+
+## Interpretation
+
+The public task lifecycle is working on devnet. The main compatibility problem is not the happy path. The drift appears in error naming, validation ordering, and lower-level account failures replacing higher-level semantic errors.
+
+That points to one of these conditions:
+
+1. The devnet-deployed program is older or otherwise different from the local source used to derive SDK expectations.
+2. The runtime IDL or error map used by the SDK is newer than the deployed devnet program.
+3. Some devnet code paths are surfacing framework-level Anchor account errors where the current local code expects protocol-level errors.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "api:baseline:generate": "node scripts/check-api-baseline.mjs --generate",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "prepublishOnly": "npm run build",
+    "test:devnet:deep": "AGENC_DEVNET_DRIFT_MODE=compat node scripts/devnet-integration-deep.mjs",
+    "test:devnet:deep:strict": "AGENC_DEVNET_DRIFT_MODE=strict node scripts/devnet-integration-deep.mjs",
+    "test:devnet:public": "node scripts/devnet-integration.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/scripts/devnet-integration-deep.mjs
+++ b/scripts/devnet-integration-deep.mjs
@@ -1,0 +1,635 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import crypto from "node:crypto";
+import { Connection, Keypair } from "@solana/web3.js";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import * as sdk from "../dist/index.mjs";
+
+const DEFAULT_RPC_URL = process.env.AGENC_RPC_URL ?? sdk.DEVNET_RPC;
+const DEFAULT_IDL_PATH =
+  process.env.AGENC_IDL_PATH ??
+  "/Users/pchmirenko/AgenC-pr1469-fix/runtime/idl/agenc_coordination.json";
+const DEFAULT_COMMITMENT = "confirmed";
+const DEFAULT_ENDPOINT = "https://example.invalid/agenc-devnet-deep-test";
+const DEFAULT_REWARD = 10_000_000n;
+const COOLDOWN_BUFFER_SECONDS = 5;
+const DEFAULT_DRIFT_MODE = process.env.AGENC_DEVNET_DRIFT_MODE ?? "compat";
+
+const KNOWN_DEVNET_DRIFT = {
+  "register agent below min stake": "InsufficientFunds",
+  "create task with past deadline": "UpdateTooFrequent",
+  "reject self-claim by creator": "ProposalUnauthorizedCancel",
+  "reject complete without claim": "AccountNotInitialized",
+  "reject cancel after complete": "AccountNotInitialized",
+};
+
+function usage() {
+  process.stdout.write(`Usage:
+  CREATOR_WALLET=/path/to/creator.json WORKER_WALLET=/path/to/worker.json npm run test:devnet:deep
+
+Environment:
+  CREATOR_WALLET          Required
+  WORKER_WALLET           Required
+  AGENC_RPC_URL           Optional (default: ${DEFAULT_RPC_URL})
+  AGENC_IDL_PATH          Optional (default: ${DEFAULT_IDL_PATH})
+  AGENC_DEVNET_DRIFT_MODE Optional: compat|strict (default: ${DEFAULT_DRIFT_MODE})
+`);
+}
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+async function loadJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function loadKeypair(path) {
+  const raw = await loadJson(path);
+  if (!Array.isArray(raw)) {
+    throw new Error(`Invalid keypair file: ${path}`);
+  }
+  return Keypair.fromSecretKey(Uint8Array.from(raw));
+}
+
+function makeWallet(keypair) {
+  return {
+    publicKey: keypair.publicKey,
+    async signTransaction(tx) {
+      tx.partialSign(keypair);
+      return tx;
+    },
+    async signAllTransactions(txs) {
+      for (const tx of txs) {
+        tx.partialSign(keypair);
+      }
+      return txs;
+    },
+  };
+}
+
+function fixedDescription(text) {
+  const out = Buffer.alloc(64);
+  const input = Buffer.from(text, "utf8");
+  input.copy(out, 0, 0, Math.min(input.length, out.length));
+  return out;
+}
+
+function short(pubkey) {
+  const base58 = pubkey.toBase58();
+  return `${base58.slice(0, 4)}...${base58.slice(-4)}`;
+}
+
+function decodeErrorName(error) {
+  const decoded = sdk.decodeAnchorError(error)?.name;
+  if (decoded) return decoded;
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/Error Code:\s+([A-Za-z0-9_]+)/);
+  return match?.[1] ?? null;
+}
+
+function toInt(value, fallback = 0) {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (value && typeof value === "object") {
+    if (typeof value.toNumber === "function") return value.toNumber();
+    if (typeof value.toString === "function") {
+      const parsed = Number(value.toString());
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForTaskCreationCooldown(seconds, reason) {
+  if (seconds <= 0) return;
+  const waitSeconds = seconds + COOLDOWN_BUFFER_SECONDS;
+  console.log(`[setup] waiting ${waitSeconds}s before ${reason}`);
+  await sleep(waitSeconds * 1000);
+}
+
+function decodedSummary(error) {
+  const decoded = sdk.decodeAnchorError(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return decoded
+    ? `${decoded.name}: ${decoded.message}`
+    : message;
+}
+
+async function expectFailure(label, allowedNames, fn) {
+  try {
+    await fn();
+  } catch (error) {
+    const decodedName = decodeErrorName(error);
+    if (decodedName && allowedNames.includes(decodedName)) {
+      console.log(`[pass] ${label}: ${decodedName}`);
+      return decodedName;
+    }
+    throw new Error(
+      `${label} failed with unexpected error: ${decodedSummary(error)}`,
+    );
+  }
+  throw new Error(
+    `${label} unexpectedly succeeded; expected one of ${allowedNames.join(", ")}`,
+  );
+}
+
+function noteMismatch(mismatches, label, expected, actual) {
+  const finding = {
+    label,
+    expected,
+    actual,
+    known: KNOWN_DEVNET_DRIFT[label] === actual,
+  };
+  mismatches.push(finding);
+  console.warn(
+    `${finding.known ? "[drift]" : "[mismatch]"} ${label}: expected ${expected}, got ${actual}`,
+  );
+}
+
+async function maybeCancelTask(connection, program, creator, taskPda, label) {
+  try {
+    const { txSignature } = await sdk.cancelTask(
+      connection,
+      program,
+      creator,
+      taskPda,
+    );
+    console.log(`[cleanup] ${label} cancelled: ${txSignature}`);
+  } catch (error) {
+    console.warn(`[cleanup] ${label} cancel skipped: ${decodedSummary(error)}`);
+  }
+}
+
+async function maybeDeregister(connection, program, authority, agentId, label) {
+  try {
+    const { txSignature } = await sdk.deregisterAgent(
+      connection,
+      program,
+      authority,
+      agentId,
+    );
+    console.log(`[cleanup] ${label} deregistered: ${txSignature}`);
+  } catch (error) {
+    console.warn(
+      `[cleanup] ${label} deregister skipped: ${decodedSummary(error)}`,
+    );
+  }
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    usage();
+    return;
+  }
+
+  const driftMode = DEFAULT_DRIFT_MODE;
+  if (driftMode !== "compat" && driftMode !== "strict") {
+    throw new Error(
+      `Invalid AGENC_DEVNET_DRIFT_MODE: ${driftMode}. Expected compat or strict.`,
+    );
+  }
+
+  const creatorWalletPath = env("CREATOR_WALLET");
+  const workerWalletPath = env("WORKER_WALLET");
+  const [creator, worker, idl] = await Promise.all([
+    loadKeypair(creatorWalletPath),
+    loadKeypair(workerWalletPath),
+    loadJson(DEFAULT_IDL_PATH),
+  ]);
+
+  if (creator.publicKey.equals(worker.publicKey)) {
+    throw new Error("CREATOR_WALLET and WORKER_WALLET must be different.");
+  }
+
+  const connection = new Connection(DEFAULT_RPC_URL, DEFAULT_COMMITMENT);
+  const creatorProgram = new Program(
+    idl,
+    new AnchorProvider(connection, makeWallet(creator), {
+      commitment: DEFAULT_COMMITMENT,
+    }),
+  );
+  const workerProgram = new Program(
+    idl,
+    new AnchorProvider(connection, makeWallet(worker), {
+      commitment: DEFAULT_COMMITMENT,
+    }),
+  );
+
+  const protocolConfig = await sdk.getProtocolConfig(creatorProgram);
+  if (!protocolConfig) {
+    throw new Error("Protocol config not found on devnet.");
+  }
+
+  const creatorAgentId = crypto.randomBytes(32);
+  const workerAgentId = crypto.randomBytes(32);
+  const createdTasks = [];
+  const results = [];
+  const mismatches = [];
+  const rawProtocolConfig = await creatorProgram.account.protocolConfig.fetch(
+    sdk.deriveProtocolPda(creatorProgram.programId),
+  );
+  const taskCreationCooldown = Math.max(
+    toInt(
+      rawProtocolConfig.taskCreationCooldown ??
+        rawProtocolConfig.task_creation_cooldown,
+      60,
+    ),
+    0,
+  );
+
+  console.log(
+    `[setup] creator=${short(creator.publicKey)} worker=${short(worker.publicKey)} minStake=${protocolConfig.minAgentStake.toString()} taskCreationCooldown=${taskCreationCooldown}s driftMode=${driftMode}`,
+  );
+
+  try {
+    const belowMinStakeResult = await expectFailure(
+      "register agent below min stake",
+      ["InsufficientStake", "InsufficientFunds"],
+      async () =>
+        sdk.registerAgent(connection, creatorProgram, creator, {
+          agentId: crypto.randomBytes(32),
+          capabilities: 1n,
+          endpoint: DEFAULT_ENDPOINT,
+          metadataUri: null,
+          stakeAmount: protocolConfig.minAgentStake - 1n,
+        }),
+    );
+    results.push(belowMinStakeResult);
+    if (belowMinStakeResult !== "InsufficientStake") {
+      noteMismatch(
+        mismatches,
+        "register agent below min stake",
+        "InsufficientStake",
+        belowMinStakeResult,
+      );
+    }
+
+    const creatorRegistration = await sdk.registerAgent(
+      connection,
+      creatorProgram,
+      creator,
+      {
+        agentId: creatorAgentId,
+        capabilities: 2n,
+        endpoint: DEFAULT_ENDPOINT,
+        metadataUri: null,
+        stakeAmount: protocolConfig.minAgentStake,
+      },
+    );
+    console.log(
+      `[step] creator agent registered: ${creatorRegistration.txSignature}`,
+    );
+
+    const workerRegistration = await sdk.registerAgent(
+      connection,
+      workerProgram,
+      worker,
+      {
+        agentId: workerAgentId,
+        capabilities: 1n,
+        endpoint: DEFAULT_ENDPOINT,
+        metadataUri: null,
+        stakeAmount: protocolConfig.minAgentStake,
+      },
+    );
+    console.log(
+      `[step] worker agent registered: ${workerRegistration.txSignature}`,
+    );
+
+    if (taskCreationCooldown > 0) {
+      console.log(
+        `[setup] waiting ${taskCreationCooldown + COOLDOWN_BUFFER_SECONDS}s for task creation cooldown`,
+      );
+      await sleep((taskCreationCooldown + COOLDOWN_BUFFER_SECONDS) * 1000);
+    }
+
+    const pastDeadlineResult = await expectFailure(
+      "create task with past deadline",
+      ["InvalidInput", "InvalidDeadline", "CooldownNotElapsed", "UpdateTooFrequent"],
+      async () =>
+        sdk.createTask(connection, creatorProgram, creator, creatorAgentId, {
+          taskId: crypto.randomBytes(32),
+          requiredCapabilities: 1n,
+          description: fixedDescription("past deadline should fail"),
+          rewardAmount: DEFAULT_REWARD,
+          maxWorkers: 1,
+          deadline: Math.floor(Date.now() / 1000) - 60,
+          taskType: 0,
+          constraintHash: null,
+          minReputation: 0,
+          rewardMint: null,
+        }),
+    );
+    results.push(pastDeadlineResult);
+    if (pastDeadlineResult !== "InvalidInput") {
+      noteMismatch(
+        mismatches,
+        "create task with past deadline",
+        "InvalidInput",
+        pastDeadlineResult,
+      );
+    }
+    if (
+      pastDeadlineResult === "CooldownNotElapsed" ||
+      pastDeadlineResult === "UpdateTooFrequent"
+    ) {
+      console.log("[setup] waiting extra 10s after cooldown-style mismatch");
+      await sleep(10_000);
+    }
+
+    const capabilityTask = await sdk.createTask(
+      connection,
+      creatorProgram,
+      creator,
+      creatorAgentId,
+      {
+        taskId: crypto.randomBytes(32),
+        requiredCapabilities: 2n,
+        description: fixedDescription("capability mismatch"),
+        rewardAmount: DEFAULT_REWARD,
+        maxWorkers: 1,
+        deadline: Math.floor(Date.now() / 1000) + 3600,
+        taskType: 0,
+        constraintHash: null,
+        minReputation: 0,
+        rewardMint: null,
+      },
+    );
+    createdTasks.push({ taskPda: capabilityTask.taskPda, label: "capability task" });
+
+    results.push(
+      await expectFailure(
+        "reject insufficient capabilities on claim",
+        ["InsufficientCapabilities"],
+        async () =>
+          sdk.claimTask(
+            connection,
+            workerProgram,
+            worker,
+            workerAgentId,
+            capabilityTask.taskPda,
+          ),
+      ),
+    );
+
+    const selfClaimResult = await expectFailure(
+      "reject self-claim by creator",
+      ["SelfTaskNotAllowed", "ProposalUnauthorizedCancel"],
+      async () =>
+        sdk.claimTask(
+          connection,
+          creatorProgram,
+          creator,
+          creatorAgentId,
+          capabilityTask.taskPda,
+        ),
+    );
+    results.push(selfClaimResult);
+    if (selfClaimResult !== "SelfTaskNotAllowed") {
+      noteMismatch(
+        mismatches,
+        "reject self-claim by creator",
+        "SelfTaskNotAllowed",
+        selfClaimResult,
+      );
+    }
+
+    await maybeCancelTask(
+      connection,
+      creatorProgram,
+      creator,
+      capabilityTask.taskPda,
+      "capability task",
+    );
+    await waitForTaskCreationCooldown(
+      taskCreationCooldown,
+      "creating the unclaimed task",
+    );
+
+    const unclaimedTask = await sdk.createTask(
+      connection,
+      creatorProgram,
+      creator,
+      creatorAgentId,
+      {
+        taskId: crypto.randomBytes(32),
+        requiredCapabilities: 1n,
+        description: fixedDescription("complete without claim"),
+        rewardAmount: DEFAULT_REWARD,
+        maxWorkers: 1,
+        deadline: Math.floor(Date.now() / 1000) + 3600,
+        taskType: 0,
+        constraintHash: null,
+        minReputation: 0,
+        rewardMint: null,
+      },
+    );
+    createdTasks.push({ taskPda: unclaimedTask.taskPda, label: "unclaimed task" });
+
+    const completeWithoutClaimResult = await expectFailure(
+      "reject complete without claim",
+      ["NotClaimed", "AccountNotInitialized"],
+      async () =>
+        sdk.completeTask(
+          connection,
+          workerProgram,
+          worker,
+          workerAgentId,
+          unclaimedTask.taskPda,
+          crypto.randomBytes(32),
+          null,
+        ),
+    );
+    results.push(completeWithoutClaimResult);
+    if (completeWithoutClaimResult !== "NotClaimed") {
+      noteMismatch(
+        mismatches,
+        "reject complete without claim",
+        "NotClaimed",
+        completeWithoutClaimResult,
+      );
+    }
+
+    await maybeCancelTask(
+      connection,
+      creatorProgram,
+      creator,
+      unclaimedTask.taskPda,
+      "unclaimed task",
+    );
+    await waitForTaskCreationCooldown(
+      taskCreationCooldown,
+      "creating the happy-path task",
+    );
+
+    const happyTask = await sdk.createTask(
+      connection,
+      creatorProgram,
+      creator,
+      creatorAgentId,
+      {
+        taskId: crypto.randomBytes(32),
+        requiredCapabilities: 1n,
+        description: fixedDescription("deep happy path"),
+        rewardAmount: DEFAULT_REWARD,
+        maxWorkers: 1,
+        deadline: Math.floor(Date.now() / 1000) + 3600,
+        taskType: 0,
+        constraintHash: null,
+        minReputation: 0,
+        rewardMint: null,
+      },
+    );
+    createdTasks.push({ taskPda: happyTask.taskPda, label: "happy task" });
+    console.log(`[step] happy task created: ${happyTask.txSignature}`);
+
+    const claimResult = await sdk.claimTask(
+      connection,
+      workerProgram,
+      worker,
+      workerAgentId,
+      happyTask.taskPda,
+    );
+    console.log(`[step] happy task claimed: ${claimResult.txSignature}`);
+
+    results.push(
+      await expectFailure(
+        "reject deregister with active task",
+        ["AgentHasActiveTasks"],
+        async () =>
+          sdk.deregisterAgent(
+            connection,
+            workerProgram,
+            worker,
+            workerAgentId,
+          ),
+      ),
+    );
+
+    const completed = await sdk.completeTask(
+      connection,
+      workerProgram,
+      worker,
+      workerAgentId,
+      happyTask.taskPda,
+      crypto.randomBytes(32),
+      null,
+    );
+    console.log(`[step] happy task completed: ${completed.txSignature}`);
+
+    const cancelAfterCompleteResult = await expectFailure(
+      "reject cancel after complete",
+      [
+        "InvalidStatusTransition",
+        "TaskCannotBeCancelled",
+        "AccountNotInitialized",
+      ],
+      async () =>
+        sdk.cancelTask(
+          connection,
+          creatorProgram,
+          creator,
+          happyTask.taskPda,
+        ),
+    );
+    results.push(cancelAfterCompleteResult);
+    if (
+      cancelAfterCompleteResult !== "InvalidStatusTransition" &&
+      cancelAfterCompleteResult !== "TaskCannotBeCancelled"
+    ) {
+      noteMismatch(
+        mismatches,
+        "reject cancel after complete",
+        "InvalidStatusTransition|TaskCannotBeCancelled",
+        cancelAfterCompleteResult,
+      );
+    }
+
+    const finalTask = await sdk.getTask(creatorProgram, happyTask.taskPda);
+    if (!finalTask || finalTask.state !== sdk.TaskState.Completed) {
+      throw new Error("Happy task did not end in Completed state.");
+    }
+
+    const summary = await sdk.getTaskLifecycleSummary(
+      creatorProgram,
+      happyTask.taskPda,
+    );
+    console.log(
+      `[verify] happy task state=${sdk.formatTaskState(finalTask.state)} currentWorkers=${finalTask.currentWorkers} timeline=${summary?.timeline.length ?? 0}`,
+    );
+
+    console.log(
+      `[success] deep devnet suite passed with ${results.length} negative-path assertions`,
+    );
+    if (mismatches.length > 0) {
+      const known = mismatches.filter((mismatch) => mismatch.known);
+      const unknown = mismatches.filter((mismatch) => !mismatch.known);
+
+      console.warn(
+        `[drift] observed ${mismatches.length} semantic mismatch(es): ${mismatches
+          .map(
+            (mismatch) =>
+              `${mismatch.label}: expected ${mismatch.expected}, got ${mismatch.actual}`,
+          )
+          .join("; ")}`,
+      );
+
+      if (driftMode === "strict" || unknown.length > 0) {
+        throw new Error(
+          `Deep suite found ${mismatches.length} semantic mismatch(es): ${mismatches
+            .map(
+              (mismatch) =>
+                `${mismatch.label}: expected ${mismatch.expected}, got ${mismatch.actual}`,
+            )
+            .join("; ")}`,
+        );
+      }
+
+      console.log(
+        `[compat] completed with ${known.length} known devnet drift mapping(s); strict mode would fail`,
+      );
+    }
+  } finally {
+    for (const task of createdTasks) {
+      await maybeCancelTask(
+        connection,
+        creatorProgram,
+        creator,
+        task.taskPda,
+        task.label,
+      );
+    }
+
+    await maybeDeregister(
+      connection,
+      creatorProgram,
+      creator,
+      creatorAgentId,
+      "creator agent",
+    );
+    await maybeDeregister(
+      connection,
+      workerProgram,
+      worker,
+      workerAgentId,
+      "worker agent",
+    );
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(`[failure] ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/devnet-integration.mjs
+++ b/scripts/devnet-integration.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import crypto from "node:crypto";
+import { Connection, Keypair } from "@solana/web3.js";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import * as sdk from "../dist/index.mjs";
+
+const DEFAULT_RPC_URL = process.env.AGENC_RPC_URL ?? sdk.DEVNET_RPC;
+const DEFAULT_COMMITMENT = "confirmed";
+const DEFAULT_REWARD_LAMPORTS = 10_000_000n; // 0.01 SOL
+const DEFAULT_AGENT_ENDPOINT = "https://example.invalid/agenc-devnet-test";
+const DEFAULT_IDL_PATH = "/Users/pchmirenko/AgenC-pr1469-fix/runtime/idl/agenc_coordination.json";
+
+function usage() {
+  process.stdout.write(`Usage:
+  CREATOR_WALLET=/path/to/creator.json WORKER_WALLET=/path/to/worker.json npm run test:devnet:public
+
+Environment:
+  CREATOR_WALLET          Required. Solana keypair JSON for task creator.
+  WORKER_WALLET           Required. Solana keypair JSON for task worker.
+  AGENC_RPC_URL           Optional. Defaults to ${DEFAULT_RPC_URL}
+  AGENC_REWARD_LAMPORTS   Optional. Defaults to ${DEFAULT_REWARD_LAMPORTS.toString()}
+  AGENC_IDL_PATH          Optional. Defaults to ${DEFAULT_IDL_PATH}
+
+What this validates:
+  1. Reads protocol config from devnet
+  2. Registers a creator agent
+  3. Registers a worker agent
+  4. Creates a public task
+  5. Claims the task
+  6. Completes the task
+  7. Fetches final on-chain task state
+  8. Best-effort deregisters both agents to refund stake
+`);
+}
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+async function loadKeypair(path) {
+  const raw = JSON.parse(await readFile(path, "utf8"));
+  if (!Array.isArray(raw)) {
+    throw new Error(`Invalid keypair file: ${path}`);
+  }
+  return Keypair.fromSecretKey(Uint8Array.from(raw));
+}
+
+async function loadIdl(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function makeWallet(keypair) {
+  return {
+    publicKey: keypair.publicKey,
+    async signTransaction(tx) {
+      tx.partialSign(keypair);
+      return tx;
+    },
+    async signAllTransactions(txs) {
+      for (const tx of txs) {
+        tx.partialSign(keypair);
+      }
+      return txs;
+    },
+  };
+}
+
+function short(pubkey) {
+  const base58 = pubkey.toBase58();
+  return `${base58.slice(0, 4)}...${base58.slice(-4)}`;
+}
+
+function lamportsToSol(lamports) {
+  return Number(lamports) / 1_000_000_000;
+}
+
+async function ensureBalance(connection, label, pubkey, minimumLamports) {
+  const balance = BigInt(await connection.getBalance(pubkey, DEFAULT_COMMITMENT));
+  if (balance < minimumLamports) {
+    throw new Error(
+      `${label} ${pubkey.toBase58()} has ${balance} lamports (${lamportsToSol(balance)} SOL), ` +
+        `needs at least ${minimumLamports} lamports (${lamportsToSol(minimumLamports)} SOL)`,
+    );
+  }
+  return balance;
+}
+
+function fixedDescription(text) {
+  const out = Buffer.alloc(64);
+  const input = Buffer.from(text, "utf8");
+  input.copy(out, 0, 0, Math.min(input.length, out.length));
+  return out;
+}
+
+async function maybeDeregister(connection, program, authority, agentId, label) {
+  try {
+    const { txSignature } = await sdk.deregisterAgent(
+      connection,
+      program,
+      authority,
+      agentId,
+    );
+    console.log(`[cleanup] ${label} deregistered: ${txSignature}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[cleanup] could not deregister ${label}: ${message}`);
+  }
+}
+
+async function main() {
+  if (process.argv.includes("--help")) {
+    usage();
+    return;
+  }
+
+  const creatorWalletPath = env("CREATOR_WALLET");
+  const workerWalletPath = env("WORKER_WALLET");
+  const rpcUrl = process.env.AGENC_RPC_URL ?? DEFAULT_RPC_URL;
+  const rewardLamports = BigInt(
+    process.env.AGENC_REWARD_LAMPORTS ?? DEFAULT_REWARD_LAMPORTS.toString(),
+  );
+  const idlPath = process.env.AGENC_IDL_PATH ?? DEFAULT_IDL_PATH;
+
+  console.log(`[config] rpc: ${rpcUrl}`);
+  console.log(`[config] creator wallet: ${creatorWalletPath}`);
+  console.log(`[config] worker wallet: ${workerWalletPath}`);
+  console.log(`[config] reward lamports: ${rewardLamports.toString()}`);
+  console.log(`[config] idl path: ${idlPath}`);
+
+  const [creator, worker] = await Promise.all([
+    loadKeypair(creatorWalletPath),
+    loadKeypair(workerWalletPath),
+  ]);
+  const idl = await loadIdl(idlPath);
+
+  if (creator.publicKey.equals(worker.publicKey)) {
+    throw new Error(
+      "CREATOR_WALLET and WORKER_WALLET must be different for this integration test.",
+    );
+  }
+
+  const connection = new Connection(rpcUrl, DEFAULT_COMMITMENT);
+  const creatorProvider = new AnchorProvider(
+    connection,
+    makeWallet(creator),
+    { commitment: DEFAULT_COMMITMENT },
+  );
+  const workerProvider = new AnchorProvider(
+    connection,
+    makeWallet(worker),
+    { commitment: DEFAULT_COMMITMENT },
+  );
+
+  const creatorProgram = new Program(idl, creatorProvider);
+  const workerProgram = new Program(idl, workerProvider);
+
+  const protocolConfig = await sdk.getProtocolConfig(creatorProgram);
+  if (!protocolConfig) {
+    throw new Error(
+      `Protocol config PDA ${sdk.deriveProtocolPda(sdk.PROGRAM_ID).toBase58()} does not exist on ${rpcUrl}`,
+    );
+  }
+
+  const minStake = protocolConfig.minAgentStake;
+  const creatorMinimum = minStake + rewardLamports + 20_000_000n;
+  const workerMinimum = minStake + 10_000_000n;
+
+  const [creatorBalance, workerBalance] = await Promise.all([
+    ensureBalance(connection, "creator", creator.publicKey, creatorMinimum),
+    ensureBalance(connection, "worker", worker.publicKey, workerMinimum),
+  ]);
+
+  console.log(
+    `[protocol] authority=${protocolConfig.authority.toBase58()} treasury=${protocolConfig.treasury.toBase58()} minStake=${minStake.toString()}`,
+  );
+  console.log(
+    `[balances] creator=${creatorBalance.toString()} (${lamportsToSol(creatorBalance)} SOL) worker=${workerBalance.toString()} (${lamportsToSol(workerBalance)} SOL)`,
+  );
+
+  const creatorAgentId = crypto.randomBytes(32);
+  const workerAgentId = crypto.randomBytes(32);
+  const taskId = crypto.randomBytes(32);
+  const proofHash = crypto.randomBytes(32);
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+  const description = fixedDescription(
+    `agenc-sdk devnet integration ${new Date().toISOString()}`,
+  );
+
+  console.log(
+    `[actors] creator=${short(creator.publicKey)} worker=${short(worker.publicKey)}`,
+  );
+
+  let taskPda = null;
+
+  try {
+    const creatorReg = await sdk.registerAgent(
+      connection,
+      creatorProgram,
+      creator,
+      {
+        agentId: creatorAgentId,
+        capabilities: 1n,
+        endpoint: DEFAULT_AGENT_ENDPOINT,
+        metadataUri: null,
+        stakeAmount: minStake,
+      },
+    );
+    console.log(`[step] creator agent registered: ${creatorReg.txSignature}`);
+
+    const workerReg = await sdk.registerAgent(
+      connection,
+      workerProgram,
+      worker,
+      {
+        agentId: workerAgentId,
+        capabilities: 1n,
+        endpoint: DEFAULT_AGENT_ENDPOINT,
+        metadataUri: null,
+        stakeAmount: minStake,
+      },
+    );
+    console.log(`[step] worker agent registered: ${workerReg.txSignature}`);
+
+    const created = await sdk.createTask(
+      connection,
+      creatorProgram,
+      creator,
+      creatorAgentId,
+      {
+        taskId,
+        requiredCapabilities: 1n,
+        description,
+        rewardAmount: rewardLamports,
+        maxWorkers: 1,
+        deadline,
+        taskType: 0,
+        constraintHash: null,
+        minReputation: 0,
+        rewardMint: null,
+      },
+    );
+    taskPda = created.taskPda;
+    console.log(
+      `[step] task created: ${created.txSignature} taskPda=${created.taskPda.toBase58()}`,
+    );
+
+    const claimed = await sdk.claimTask(
+      connection,
+      workerProgram,
+      worker,
+      workerAgentId,
+      created.taskPda,
+    );
+    console.log(`[step] task claimed: ${claimed.txSignature}`);
+
+    const completed = await sdk.completeTask(
+      connection,
+      workerProgram,
+      worker,
+      workerAgentId,
+      created.taskPda,
+      proofHash,
+      null,
+    );
+    console.log(`[step] task completed: ${completed.txSignature}`);
+
+    const task = await sdk.getTask(creatorProgram, created.taskPda);
+    if (!task) {
+      throw new Error("Task account could not be fetched after completion.");
+    }
+
+    console.log(
+      `[result] state=${sdk.formatTaskState(task.state)} reward=${task.rewardAmount.toString()} completedAt=${task.completedAt ?? "null"}`,
+    );
+
+    if (task.state !== sdk.TaskState.Completed) {
+      throw new Error(
+        `Expected task state Completed, got ${sdk.formatTaskState(task.state)}`,
+      );
+    }
+
+    console.log("[success] devnet public integration flow passed");
+  } finally {
+    await maybeDeregister(connection, creatorProgram, creator, creatorAgentId, "creator agent");
+    await maybeDeregister(connection, workerProgram, worker, workerAgentId, "worker agent");
+
+    if (taskPda) {
+      console.log(`[final] taskPda=${taskPda.toBase58()}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(`[failure] ${message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

This PR updates the devnet integration coverage to support the current behavior of the program deployed on Solana devnet, while still making semantic drift explicit.

The goal is not to normalize or hide mismatches. The goal is to let devnet lifecycle coverage pass in a compatibility mode, and keep a strict mode that still fails until devnet behavior matches current local expectations.

## What changed

- add a public devnet integration harness for the end-to-end public lifecycle
- add a deep devnet integration harness with `compat` and `strict` drift modes
- keep known devnet drift visible in test output instead of silently normalizing it
- add package scripts for public, compat, and strict devnet runs
- add a documented compatibility report mapping expected local errors to observed devnet errors
- respect live devnet task creation cooldowns in the deep suite

## Files changed

- `scripts/devnet-integration.mjs`
- `scripts/devnet-integration-deep.mjs`
- `package.json`
- `docs/devnet-compatibility.md`

## Harness behavior

### Compat mode

`npm run test:devnet:deep`

- passes when only known devnet drift is observed
- logs each known mismatch explicitly
- still fails on unknown drift

### Strict mode

`npm run test:devnet:deep:strict`

- fails on any semantic drift, including the currently known devnet mismatches

## Known devnet drift currently documented

| Scenario | Expected local error | Observed devnet error |
| --- | --- | --- |
| Register below min stake | `InsufficientStake` | `InsufficientFunds` |
| Create task with past deadline | `InvalidInput` | `UpdateTooFrequent` |
| Creator self-claims own task | `SelfTaskNotAllowed` | `ProposalUnauthorizedCancel` |
| Complete without claim | `NotClaimed` | `AccountNotInitialized` |
| Cancel after complete | `InvalidStatusTransition` or `TaskCannotBeCancelled` | `AccountNotInitialized` |

## Why

The public devnet lifecycle is working, but the deployed devnet program behavior is not fully aligned with current local source and SDK expectations.

Without this change:

- deep devnet coverage fails even when the happy path is healthy
- developers cannot distinguish expected devnet drift from new regressions

With this change:

- devnet coverage remains useful
- drift stays visible
- strict mode still protects against masking real incompatibilities

## Validation

Validated on devnet with funded creator and worker wallets.

Confirmed:

- register creator agent
- register worker agent
- create public task
- claim task
- complete task
- final on-chain task state = `Completed`
- deregister while active task still rejects correctly
- cleanup deregistration succeeds at the end

Public flow run:

```bash
CREATOR_WALLET=/Users/pchmirenko/.config/solana/agenc-sdk-devnet/creator.json \
WORKER_WALLET=/Users/pchmirenko/.config/solana/agenc-sdk-devnet/worker.json \
npm run test:devnet:public
```

Deep compat run:

```bash
CREATOR_WALLET=/Users/pchmirenko/.config/solana/agenc-sdk-devnet/creator.json \
WORKER_WALLET=/Users/pchmirenko/.config/solana/agenc-sdk-devnet/worker.json \
npm run test:devnet:deep
```

Compat mode completes successfully and prints the drift summary. Strict mode remains available for exact expectation matching.

## Follow-up

This PR does not resolve the underlying devnet/local mismatch.

A separate follow-up should track:

- deployed devnet program vs local source alignment
- IDL and error-map alignment
- whether framework-level Anchor errors are surfacing where protocol-level errors are expected
