### PR TITLE
fix(build): externalize @coral-xyz/anchor and use namespace import to fix BN interopfix(build): externalize @coral-xyz/anchor and use namespace import to fix BN interop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3346,9 +3346,10 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/spl-token.ts --format cjs,esm --dts --clean --external privacycash",
+    "build": "tsup src/index.ts src/spl-token.ts --format cjs,esm --dts --clean --external privacycash --external @coral-xyz/anchor",
     "api:baseline:check": "node scripts/check-api-baseline.mjs --check",
     "api:baseline:generate": "node scripts/check-api-baseline.mjs --generate",
     "pack:smoke": "node scripts/pack-smoke.mjs",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,5 +1,6 @@
 import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { type Program } from "@coral-xyz/anchor";
 import { PROGRAM_ID, SEEDS } from "./constants";
 import { getAccount } from "./anchor-utils";
 import { deriveProtocolPda } from "./protocol";

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -3,7 +3,8 @@
  */
 
 import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { type Program } from "@coral-xyz/anchor";
 import { PROGRAM_ID, SEEDS } from "./constants.js";
 import { getAccount } from "./anchor-utils.js";
 import { deriveProtocolPda } from "./protocol.js";

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -5,7 +5,8 @@ import {
   SystemProgram,
   type AccountMeta,
 } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { type Program } from "@coral-xyz/anchor";
 import { PROGRAM_ID, SEEDS } from "./constants";
 import { getAccount } from "./anchor-utils";
 import { toBigInt, toNumber } from "./utils/numeric";

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
 import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { type Program } from "@coral-xyz/anchor";
 import { PROGRAM_ID } from "./constants";
 import { getAccount } from "./anchor-utils";
 import { deriveProtocolPda } from "./protocol";

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -12,7 +12,8 @@ import {
   SystemProgram,
   ComputeBudgetProgram,
 } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { type Program } from "@coral-xyz/anchor";
 import {
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,


### PR DESCRIPTION
Fixes #8

## What changed

Five SDK source files used `import anchor from "@coral-xyz/anchor"` (default import) then called `new anchor.BN(...)`. This fails in both CJS and ESM because `@coral-xyz/anchor` does not expose a default export with `BN`.

**Two changes:**
- Switch to `import * as anchor from "@coral-xyz/anchor"` (namespace import) in `agents.ts`, `tasks.ts`, `governance.ts`, `protocol.ts`, `state.ts`
- Add `--external @coral-xyz/anchor` to the tsup build command so the module is not bundled through `__toESM`

## Verification

`registerAgent` now successfully submits to devnet:
TX: `59rZ1gi4GYWTqWkTR162goums7RA9boUdwh1uGFEcoVNEGtqcfZhiG9ZGBi1ws1D73EuiGBicPr8YVjmZ1uvhJCT`