### PR TITLE
fix(errors): regenerate SDK error map from IDL snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,13 @@ Every release must pass:
 
 ## Protocol alignment note
 
-Protocol-IDL alignment is intentionally not tested in this repo yet. The old
-monorepo `target/idl/agenc_coordination.json`-based test was removed from this
-repo because it depended on a private monorepo build artifact. Gate 11 moves
-that contract check into the future protocol repo or a cross-repo integration
-job.
+Full protocol-IDL alignment is intentionally not tested in this repo yet. The
+old monorepo `target/idl/agenc_coordination.json`-based test was removed from
+this repo because it depended on a private monorepo build artifact. Gate 11
+moves that contract check into the future protocol repo or a cross-repo
+integration job.
+
+The SDK error map is still guarded here. `src/errors.ts` is regenerated from a
+committed snapshot of protocol IDL errors in `data/coordination-idl-errors.json`.
+Refresh that snapshot from the protocol repo with
+`AGENC_IDL_PATH=/absolute/path/to/agenc_coordination.json npm run errors:generate`.

--- a/data/coordination-idl-errors.json
+++ b/data/coordination-idl-errors.json
@@ -1,0 +1,1002 @@
+[
+  {
+    "code": 6000,
+    "name": "AgentAlreadyRegistered",
+    "message": "Agent is already registered"
+  },
+  {
+    "code": 6001,
+    "name": "AgentNotFound",
+    "message": "Agent not found"
+  },
+  {
+    "code": 6002,
+    "name": "AgentNotActive",
+    "message": "Agent is not active"
+  },
+  {
+    "code": 6003,
+    "name": "InsufficientCapabilities",
+    "message": "Agent has insufficient capabilities"
+  },
+  {
+    "code": 6004,
+    "name": "InvalidCapabilities",
+    "message": "Agent capabilities bitmask cannot be zero"
+  },
+  {
+    "code": 6005,
+    "name": "MaxActiveTasksReached",
+    "message": "Agent has reached maximum active tasks"
+  },
+  {
+    "code": 6006,
+    "name": "AgentHasActiveTasks",
+    "message": "Agent has active tasks and cannot be deregistered"
+  },
+  {
+    "code": 6007,
+    "name": "UnauthorizedAgent",
+    "message": "Only the agent authority can perform this action"
+  },
+  {
+    "code": 6008,
+    "name": "CreatorAuthorityMismatch",
+    "message": "Creator must match authority to prevent social engineering"
+  },
+  {
+    "code": 6009,
+    "name": "InvalidAgentId",
+    "message": "Invalid agent ID: agent_id cannot be all zeros"
+  },
+  {
+    "code": 6010,
+    "name": "AgentRegistrationRequired",
+    "message": "Agent registration required to create tasks"
+  },
+  {
+    "code": 6011,
+    "name": "AgentSuspended",
+    "message": "Agent is suspended and cannot change status"
+  },
+  {
+    "code": 6012,
+    "name": "AgentBusyWithTasks",
+    "message": "Agent cannot set status to Active while having active tasks"
+  },
+  {
+    "code": 6013,
+    "name": "TaskNotFound",
+    "message": "Task not found"
+  },
+  {
+    "code": 6014,
+    "name": "TaskNotOpen",
+    "message": "Task is not open for claims"
+  },
+  {
+    "code": 6015,
+    "name": "TaskFullyClaimed",
+    "message": "Task has reached maximum workers"
+  },
+  {
+    "code": 6016,
+    "name": "TaskExpired",
+    "message": "Task has expired"
+  },
+  {
+    "code": 6017,
+    "name": "TaskNotExpired",
+    "message": "Task deadline has not passed"
+  },
+  {
+    "code": 6018,
+    "name": "DeadlinePassed",
+    "message": "Task deadline has passed"
+  },
+  {
+    "code": 6019,
+    "name": "TaskNotInProgress",
+    "message": "Task is not in progress"
+  },
+  {
+    "code": 6020,
+    "name": "TaskAlreadyCompleted",
+    "message": "Task is already completed"
+  },
+  {
+    "code": 6021,
+    "name": "TaskCannotBeCancelled",
+    "message": "Task cannot be cancelled"
+  },
+  {
+    "code": 6022,
+    "name": "UnauthorizedTaskAction",
+    "message": "Only the task creator can perform this action"
+  },
+  {
+    "code": 6023,
+    "name": "InvalidCreator",
+    "message": "Invalid creator"
+  },
+  {
+    "code": 6024,
+    "name": "InvalidTaskId",
+    "message": "Invalid task ID: cannot be zero"
+  },
+  {
+    "code": 6025,
+    "name": "InvalidDescription",
+    "message": "Invalid description: cannot be empty"
+  },
+  {
+    "code": 6026,
+    "name": "InvalidMaxWorkers",
+    "message": "Invalid max workers: must be between 1 and 100"
+  },
+  {
+    "code": 6027,
+    "name": "InvalidTaskType",
+    "message": "Invalid task type"
+  },
+  {
+    "code": 6028,
+    "name": "InvalidDeadline",
+    "message": "Invalid deadline: deadline must be greater than zero"
+  },
+  {
+    "code": 6029,
+    "name": "InvalidReward",
+    "message": "Invalid reward: reward must be greater than zero"
+  },
+  {
+    "code": 6030,
+    "name": "InvalidRequiredCapabilities",
+    "message": "Invalid required capabilities: required_capabilities cannot be zero"
+  },
+  {
+    "code": 6031,
+    "name": "CompetitiveTaskAlreadyWon",
+    "message": "Competitive task already completed by another worker"
+  },
+  {
+    "code": 6032,
+    "name": "NoWorkers",
+    "message": "Task has no workers"
+  },
+  {
+    "code": 6033,
+    "name": "ConstraintHashMismatch",
+    "message": "Proof constraint hash does not match task's stored constraint hash"
+  },
+  {
+    "code": 6034,
+    "name": "NotPrivateTask",
+    "message": "Task is not a private task (no constraint hash set)"
+  },
+  {
+    "code": 6035,
+    "name": "AlreadyClaimed",
+    "message": "Worker has already claimed this task"
+  },
+  {
+    "code": 6036,
+    "name": "NotClaimed",
+    "message": "Worker has not claimed this task"
+  },
+  {
+    "code": 6037,
+    "name": "ClaimAlreadyCompleted",
+    "message": "Claim has already been completed"
+  },
+  {
+    "code": 6038,
+    "name": "ClaimNotExpired",
+    "message": "Claim has not expired yet"
+  },
+  {
+    "code": 6039,
+    "name": "ClaimExpired",
+    "message": "Claim has expired"
+  },
+  {
+    "code": 6040,
+    "name": "InvalidExpiration",
+    "message": "Invalid expiration: expires_at cannot be zero"
+  },
+  {
+    "code": 6041,
+    "name": "InvalidProof",
+    "message": "Invalid proof of work"
+  },
+  {
+    "code": 6042,
+    "name": "ZkVerificationFailed",
+    "message": "ZK proof verification failed"
+  },
+  {
+    "code": 6043,
+    "name": "InvalidSealEncoding",
+    "message": "Invalid RISC0 seal encoding"
+  },
+  {
+    "code": 6044,
+    "name": "InvalidJournalLength",
+    "message": "Invalid RISC0 journal length"
+  },
+  {
+    "code": 6045,
+    "name": "InvalidJournalBinding",
+    "message": "Invalid RISC0 journal binding"
+  },
+  {
+    "code": 6046,
+    "name": "InvalidJournalTask",
+    "message": "RISC0 journal task binding mismatch"
+  },
+  {
+    "code": 6047,
+    "name": "InvalidJournalAuthority",
+    "message": "RISC0 journal authority binding mismatch"
+  },
+  {
+    "code": 6048,
+    "name": "InvalidImageId",
+    "message": "Invalid RISC0 image ID"
+  },
+  {
+    "code": 6049,
+    "name": "TrustedSelectorMismatch",
+    "message": "RISC0 seal selector does not match trusted selector"
+  },
+  {
+    "code": 6050,
+    "name": "TrustedVerifierProgramMismatch",
+    "message": "RISC0 verifier program does not match trusted verifier"
+  },
+  {
+    "code": 6051,
+    "name": "RouterAccountMismatch",
+    "message": "RISC0 router account constraints failed"
+  },
+  {
+    "code": 6052,
+    "name": "InvalidProofSize",
+    "message": "Invalid proof size - expected 256 bytes for RISC Zero seal body"
+  },
+  {
+    "code": 6053,
+    "name": "InvalidProofBinding",
+    "message": "Invalid proof binding: expected_binding cannot be all zeros"
+  },
+  {
+    "code": 6054,
+    "name": "InvalidOutputCommitment",
+    "message": "Invalid output commitment: output_commitment cannot be all zeros"
+  },
+  {
+    "code": 6055,
+    "name": "InvalidRentRecipient",
+    "message": "Invalid rent recipient: must be worker authority"
+  },
+  {
+    "code": 6056,
+    "name": "GracePeriodNotPassed",
+    "message": "Grace period not passed: only worker authority can expire claim within 60 seconds of expiry"
+  },
+  {
+    "code": 6057,
+    "name": "InvalidProofHash",
+    "message": "Invalid proof hash: proof_hash cannot be all zeros"
+  },
+  {
+    "code": 6058,
+    "name": "InvalidResultData",
+    "message": "Invalid result data: result_data cannot be all zeros when provided"
+  },
+  {
+    "code": 6059,
+    "name": "DisputeNotActive",
+    "message": "Dispute is not active"
+  },
+  {
+    "code": 6060,
+    "name": "VotingEnded",
+    "message": "Voting period has ended"
+  },
+  {
+    "code": 6061,
+    "name": "VotingNotEnded",
+    "message": "Voting period has not ended"
+  },
+  {
+    "code": 6062,
+    "name": "AlreadyVoted",
+    "message": "Already voted on this dispute"
+  },
+  {
+    "code": 6063,
+    "name": "NotArbiter",
+    "message": "Not authorized to vote (not an arbiter)"
+  },
+  {
+    "code": 6064,
+    "name": "InsufficientVotes",
+    "message": "Insufficient votes to resolve"
+  },
+  {
+    "code": 6065,
+    "name": "DisputeAlreadyResolved",
+    "message": "Dispute has already been resolved"
+  },
+  {
+    "code": 6066,
+    "name": "UnauthorizedResolver",
+    "message": "Only protocol authority or dispute initiator can resolve disputes"
+  },
+  {
+    "code": 6067,
+    "name": "ActiveDisputeVotes",
+    "message": "Agent has active dispute votes pending resolution"
+  },
+  {
+    "code": 6068,
+    "name": "RecentVoteActivity",
+    "message": "Agent must wait 24 hours after voting before deregistering"
+  },
+  {
+    "code": 6069,
+    "name": "AuthorityAlreadyVoted",
+    "message": "Authority has already voted on this dispute"
+  },
+  {
+    "code": 6070,
+    "name": "InsufficientEvidence",
+    "message": "Insufficient dispute evidence provided"
+  },
+  {
+    "code": 6071,
+    "name": "EvidenceTooLong",
+    "message": "Dispute evidence exceeds maximum allowed length"
+  },
+  {
+    "code": 6072,
+    "name": "DisputeNotExpired",
+    "message": "Dispute has not expired"
+  },
+  {
+    "code": 6073,
+    "name": "SlashAlreadyApplied",
+    "message": "Dispute slashing already applied"
+  },
+  {
+    "code": 6074,
+    "name": "SlashWindowExpired",
+    "message": "Slash window expired: must apply slashing within 7 days of resolution"
+  },
+  {
+    "code": 6075,
+    "name": "DisputeNotResolved",
+    "message": "Dispute has not been resolved"
+  },
+  {
+    "code": 6076,
+    "name": "NotTaskParticipant",
+    "message": "Only task creator or workers can initiate disputes"
+  },
+  {
+    "code": 6077,
+    "name": "InvalidEvidenceHash",
+    "message": "Invalid evidence hash: cannot be all zeros"
+  },
+  {
+    "code": 6078,
+    "name": "ArbiterIsDisputeParticipant",
+    "message": "Arbiter cannot vote on disputes they are a participant in"
+  },
+  {
+    "code": 6079,
+    "name": "InsufficientQuorum",
+    "message": "Insufficient quorum: minimum number of voters not reached"
+  },
+  {
+    "code": 6080,
+    "name": "ActiveDisputesExist",
+    "message": "Agent has active disputes as defendant and cannot deregister"
+  },
+  {
+    "code": 6081,
+    "name": "TooManyDisputeVoters",
+    "message": "Dispute has reached maximum voter capacity"
+  },
+  {
+    "code": 6082,
+    "name": "WorkerAgentRequired",
+    "message": "Worker agent account required when creator initiates dispute"
+  },
+  {
+    "code": 6083,
+    "name": "WorkerClaimRequired",
+    "message": "Worker claim account required when creator initiates dispute"
+  },
+  {
+    "code": 6084,
+    "name": "WorkerNotInDispute",
+    "message": "Worker was not involved in this dispute"
+  },
+  {
+    "code": 6085,
+    "name": "InitiatorCannotResolve",
+    "message": "Dispute initiator cannot resolve their own dispute"
+  },
+  {
+    "code": 6086,
+    "name": "VersionMismatch",
+    "message": "State version mismatch (concurrent modification)"
+  },
+  {
+    "code": 6087,
+    "name": "StateKeyExists",
+    "message": "State key already exists"
+  },
+  {
+    "code": 6088,
+    "name": "StateNotFound",
+    "message": "State not found"
+  },
+  {
+    "code": 6089,
+    "name": "InvalidStateValue",
+    "message": "Invalid state value: state_value cannot be all zeros"
+  },
+  {
+    "code": 6090,
+    "name": "StateOwnershipViolation",
+    "message": "State ownership violation: only the creator agent can update this state"
+  },
+  {
+    "code": 6091,
+    "name": "InvalidStateKey",
+    "message": "Invalid state key: state_key cannot be all zeros"
+  },
+  {
+    "code": 6092,
+    "name": "ProtocolAlreadyInitialized",
+    "message": "Protocol is already initialized"
+  },
+  {
+    "code": 6093,
+    "name": "ProtocolNotInitialized",
+    "message": "Protocol is not initialized"
+  },
+  {
+    "code": 6094,
+    "name": "InvalidProtocolFee",
+    "message": "Invalid protocol fee (must be <= 1000 bps)"
+  },
+  {
+    "code": 6095,
+    "name": "InvalidTreasury",
+    "message": "Invalid treasury: treasury account cannot be default pubkey"
+  },
+  {
+    "code": 6096,
+    "name": "InvalidDisputeThreshold",
+    "message": "Invalid dispute threshold: must be 1-100 (percentage of votes required)"
+  },
+  {
+    "code": 6097,
+    "name": "InsufficientStake",
+    "message": "Insufficient stake for arbiter registration"
+  },
+  {
+    "code": 6098,
+    "name": "MultisigInvalidThreshold",
+    "message": "Invalid multisig threshold"
+  },
+  {
+    "code": 6099,
+    "name": "MultisigInvalidSigners",
+    "message": "Invalid multisig signer configuration"
+  },
+  {
+    "code": 6100,
+    "name": "MultisigNotEnoughSigners",
+    "message": "Not enough multisig signers"
+  },
+  {
+    "code": 6101,
+    "name": "MultisigDuplicateSigner",
+    "message": "Duplicate multisig signer provided"
+  },
+  {
+    "code": 6102,
+    "name": "MultisigDefaultSigner",
+    "message": "Multisig signer cannot be default pubkey"
+  },
+  {
+    "code": 6103,
+    "name": "MultisigSignerNotSystemOwned",
+    "message": "Multisig signer account not owned by System Program"
+  },
+  {
+    "code": 6104,
+    "name": "InvalidInput",
+    "message": "Invalid input parameter"
+  },
+  {
+    "code": 6105,
+    "name": "ArithmeticOverflow",
+    "message": "Arithmetic overflow"
+  },
+  {
+    "code": 6106,
+    "name": "VoteOverflow",
+    "message": "Vote count overflow"
+  },
+  {
+    "code": 6107,
+    "name": "InsufficientFunds",
+    "message": "Insufficient funds"
+  },
+  {
+    "code": 6108,
+    "name": "RewardTooSmall",
+    "message": "Reward too small: worker must receive at least 1 lamport"
+  },
+  {
+    "code": 6109,
+    "name": "CorruptedData",
+    "message": "Account data is corrupted"
+  },
+  {
+    "code": 6110,
+    "name": "StringTooLong",
+    "message": "String too long"
+  },
+  {
+    "code": 6111,
+    "name": "InvalidAccountOwner",
+    "message": "Account owner validation failed: account not owned by this program"
+  },
+  {
+    "code": 6112,
+    "name": "RateLimitExceeded",
+    "message": "Rate limit exceeded: maximum actions per 24h window reached"
+  },
+  {
+    "code": 6113,
+    "name": "CooldownNotElapsed",
+    "message": "Cooldown period has not elapsed since last action"
+  },
+  {
+    "code": 6114,
+    "name": "UpdateTooFrequent",
+    "message": "Agent update too frequent: must wait cooldown period"
+  },
+  {
+    "code": 6115,
+    "name": "InvalidCooldown",
+    "message": "Cooldown value cannot be negative"
+  },
+  {
+    "code": 6116,
+    "name": "CooldownTooLarge",
+    "message": "Cooldown value exceeds maximum (24 hours)"
+  },
+  {
+    "code": 6117,
+    "name": "RateLimitTooHigh",
+    "message": "Rate limit value exceeds maximum allowed (1000)"
+  },
+  {
+    "code": 6118,
+    "name": "CooldownTooLong",
+    "message": "Cooldown value exceeds maximum allowed (1 week)"
+  },
+  {
+    "code": 6119,
+    "name": "InsufficientStakeForDispute",
+    "message": "Insufficient stake to initiate dispute"
+  },
+  {
+    "code": 6120,
+    "name": "InsufficientStakeForCreatorDispute",
+    "message": "Creator-initiated disputes require 2x the minimum stake"
+  },
+  {
+    "code": 6121,
+    "name": "VersionMismatchProtocol",
+    "message": "Protocol version mismatch: account version incompatible with current program"
+  },
+  {
+    "code": 6122,
+    "name": "AccountVersionTooOld",
+    "message": "Account version too old: migration required"
+  },
+  {
+    "code": 6123,
+    "name": "AccountVersionTooNew",
+    "message": "Account version too new: program upgrade required"
+  },
+  {
+    "code": 6124,
+    "name": "InvalidMigrationSource",
+    "message": "Migration not allowed: invalid source version"
+  },
+  {
+    "code": 6125,
+    "name": "InvalidMigrationTarget",
+    "message": "Migration not allowed: invalid target version"
+  },
+  {
+    "code": 6126,
+    "name": "UnauthorizedUpgrade",
+    "message": "Only upgrade authority can perform this action"
+  },
+  {
+    "code": 6127,
+    "name": "UnauthorizedProtocolAuthority",
+    "message": "Only protocol authority can perform this action"
+  },
+  {
+    "code": 6128,
+    "name": "InvalidMinVersion",
+    "message": "Minimum version cannot exceed current protocol version"
+  },
+  {
+    "code": 6129,
+    "name": "ProtocolConfigRequired",
+    "message": "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts"
+  },
+  {
+    "code": 6130,
+    "name": "ParentTaskCancelled",
+    "message": "Parent task has been cancelled"
+  },
+  {
+    "code": 6131,
+    "name": "ParentTaskDisputed",
+    "message": "Parent task is in disputed state"
+  },
+  {
+    "code": 6132,
+    "name": "InvalidDependencyType",
+    "message": "Invalid dependency type"
+  },
+  {
+    "code": 6133,
+    "name": "ParentTaskNotCompleted",
+    "message": "Parent task must be completed before completing a proof-dependent task"
+  },
+  {
+    "code": 6134,
+    "name": "ParentTaskAccountRequired",
+    "message": "Parent task account required for proof-dependent task completion"
+  },
+  {
+    "code": 6135,
+    "name": "UnauthorizedCreator",
+    "message": "Parent task does not belong to the same creator"
+  },
+  {
+    "code": 6136,
+    "name": "NullifierAlreadySpent",
+    "message": "Nullifier has already been spent - proof/knowledge reuse detected"
+  },
+  {
+    "code": 6137,
+    "name": "InvalidNullifier",
+    "message": "Invalid nullifier: nullifier value cannot be all zeros"
+  },
+  {
+    "code": 6138,
+    "name": "IncompleteWorkerAccounts",
+    "message": "All worker accounts must be provided when cancelling a task with active claims"
+  },
+  {
+    "code": 6139,
+    "name": "WorkerAccountsRequired",
+    "message": "Worker accounts required when task has active workers"
+  },
+  {
+    "code": 6140,
+    "name": "DuplicateArbiter",
+    "message": "Duplicate arbiter provided in remaining_accounts"
+  },
+  {
+    "code": 6141,
+    "name": "InsufficientEscrowBalance",
+    "message": "Escrow has insufficient balance for reward transfer"
+  },
+  {
+    "code": 6142,
+    "name": "InvalidStatusTransition",
+    "message": "Invalid task status transition"
+  },
+  {
+    "code": 6143,
+    "name": "StakeTooLow",
+    "message": "Stake value is below minimum required (0.001 SOL)"
+  },
+  {
+    "code": 6144,
+    "name": "InvalidMinStake",
+    "message": "min_stake_for_dispute must be greater than zero"
+  },
+  {
+    "code": 6145,
+    "name": "InvalidSlashAmount",
+    "message": "Slash amount must be greater than zero"
+  },
+  {
+    "code": 6146,
+    "name": "BondAmountTooLow",
+    "message": "Bond amount too low"
+  },
+  {
+    "code": 6147,
+    "name": "BondAlreadyExists",
+    "message": "Bond already exists"
+  },
+  {
+    "code": 6148,
+    "name": "BondNotFound",
+    "message": "Bond not found"
+  },
+  {
+    "code": 6149,
+    "name": "BondNotMatured",
+    "message": "Bond not yet matured"
+  },
+  {
+    "code": 6150,
+    "name": "InsufficientReputation",
+    "message": "Agent reputation below task minimum requirement"
+  },
+  {
+    "code": 6151,
+    "name": "InvalidMinReputation",
+    "message": "Invalid minimum reputation: must be <= 10000"
+  },
+  {
+    "code": 6152,
+    "name": "DevelopmentKeyNotAllowed",
+    "message": "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use."
+  },
+  {
+    "code": 6153,
+    "name": "SelfTaskNotAllowed",
+    "message": "Cannot claim own task: worker authority matches task creator"
+  },
+  {
+    "code": 6154,
+    "name": "MissingTokenAccounts",
+    "message": "Token accounts not provided for token-denominated task"
+  },
+  {
+    "code": 6155,
+    "name": "InvalidTokenEscrow",
+    "message": "Token escrow ATA does not match expected derivation"
+  },
+  {
+    "code": 6156,
+    "name": "InvalidTokenMint",
+    "message": "Provided mint does not match task's reward_mint"
+  },
+  {
+    "code": 6157,
+    "name": "TokenTransferFailed",
+    "message": "SPL token transfer CPI failed"
+  },
+  {
+    "code": 6158,
+    "name": "ProposalNotActive",
+    "message": "Proposal is not active"
+  },
+  {
+    "code": 6159,
+    "name": "ProposalVotingNotEnded",
+    "message": "Voting period has not ended"
+  },
+  {
+    "code": 6160,
+    "name": "ProposalVotingEnded",
+    "message": "Voting period has ended"
+  },
+  {
+    "code": 6161,
+    "name": "ProposalAlreadyExecuted",
+    "message": "Proposal has already been executed"
+  },
+  {
+    "code": 6162,
+    "name": "ProposalInsufficientQuorum",
+    "message": "Insufficient quorum for proposal execution"
+  },
+  {
+    "code": 6163,
+    "name": "ProposalNotApproved",
+    "message": "Proposal did not achieve majority"
+  },
+  {
+    "code": 6164,
+    "name": "ProposalUnauthorizedCancel",
+    "message": "Only the proposer can cancel this proposal"
+  },
+  {
+    "code": 6165,
+    "name": "ProposalInsufficientStake",
+    "message": "Insufficient stake to create a proposal"
+  },
+  {
+    "code": 6166,
+    "name": "InvalidProposalPayload",
+    "message": "Invalid proposal payload"
+  },
+  {
+    "code": 6167,
+    "name": "InvalidProposalType",
+    "message": "Invalid proposal type"
+  },
+  {
+    "code": 6168,
+    "name": "TreasuryInsufficientBalance",
+    "message": "Treasury spend amount exceeds available balance"
+  },
+  {
+    "code": 6169,
+    "name": "TimelockNotElapsed",
+    "message": "Execution timelock has not elapsed"
+  },
+  {
+    "code": 6170,
+    "name": "InvalidGovernanceParam",
+    "message": "Invalid governance configuration parameter"
+  },
+  {
+    "code": 6171,
+    "name": "TreasuryNotProgramOwned",
+    "message": "Treasury must be a program-owned PDA"
+  },
+  {
+    "code": 6172,
+    "name": "TreasuryNotSpendable",
+    "message": "Treasury must be program-owned, or a signer system account for governance spends"
+  },
+  {
+    "code": 6173,
+    "name": "SkillInvalidId",
+    "message": "Skill ID cannot be all zeros"
+  },
+  {
+    "code": 6174,
+    "name": "SkillInvalidName",
+    "message": "Skill name cannot be all zeros"
+  },
+  {
+    "code": 6175,
+    "name": "SkillInvalidContentHash",
+    "message": "Skill content hash cannot be all zeros"
+  },
+  {
+    "code": 6176,
+    "name": "SkillNotActive",
+    "message": "Skill is not active"
+  },
+  {
+    "code": 6177,
+    "name": "SkillInvalidRating",
+    "message": "Rating must be between 1 and 5"
+  },
+  {
+    "code": 6178,
+    "name": "SkillSelfRating",
+    "message": "Cannot rate own skill"
+  },
+  {
+    "code": 6179,
+    "name": "SkillUnauthorizedUpdate",
+    "message": "Only the skill author can update this skill"
+  },
+  {
+    "code": 6180,
+    "name": "SkillSelfPurchase",
+    "message": "Cannot purchase own skill"
+  },
+  {
+    "code": 6181,
+    "name": "FeedInvalidContentHash",
+    "message": "Feed content hash cannot be all zeros"
+  },
+  {
+    "code": 6182,
+    "name": "FeedInvalidTopic",
+    "message": "Feed topic cannot be all zeros"
+  },
+  {
+    "code": 6183,
+    "name": "FeedPostNotFound",
+    "message": "Feed post not found"
+  },
+  {
+    "code": 6184,
+    "name": "FeedSelfUpvote",
+    "message": "Cannot upvote own post"
+  },
+  {
+    "code": 6185,
+    "name": "ReputationStakeAmountTooLow",
+    "message": "Reputation stake amount must be greater than zero"
+  },
+  {
+    "code": 6186,
+    "name": "ReputationStakeLocked",
+    "message": "Reputation stake is locked: withdrawal before cooldown"
+  },
+  {
+    "code": 6187,
+    "name": "ReputationStakeInsufficientBalance",
+    "message": "Reputation stake has insufficient balance for withdrawal"
+  },
+  {
+    "code": 6188,
+    "name": "ReputationDelegationAmountInvalid",
+    "message": "Reputation delegation amount invalid: must be > 0, <= 10000, and >= MIN_DELEGATION_AMOUNT"
+  },
+  {
+    "code": 6189,
+    "name": "ReputationCannotDelegateSelf",
+    "message": "Cannot delegate reputation to self"
+  },
+  {
+    "code": 6190,
+    "name": "ReputationDelegationExpired",
+    "message": "Reputation delegation has expired"
+  },
+  {
+    "code": 6191,
+    "name": "ReputationAgentNotActive",
+    "message": "Agent must be Active to participate in reputation economy"
+  },
+  {
+    "code": 6192,
+    "name": "ReputationDisputesPending",
+    "message": "Agent has pending disputes as defendant: cannot withdraw stake"
+  },
+  {
+    "code": 6193,
+    "name": "PrivateTaskRequiresZkProof",
+    "message": "Private tasks (non-zero constraint_hash) must use complete_task_private"
+  },
+  {
+    "code": 6194,
+    "name": "InvalidTokenAccountOwner",
+    "message": "Token account owner does not match expected authority"
+  },
+  {
+    "code": 6195,
+    "name": "InsufficientSeedEntropy",
+    "message": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
+  },
+  {
+    "code": 6196,
+    "name": "SkillPriceBelowMinimum",
+    "message": "Skill price below minimum required"
+  },
+  {
+    "code": 6197,
+    "name": "SkillPriceChanged",
+    "message": "Skill price changed since transaction was prepared"
+  },
+  {
+    "code": 6198,
+    "name": "DelegationCooldownNotElapsed",
+    "message": "Delegation must be active for minimum duration before revocation"
+  },
+  {
+    "code": 6199,
+    "name": "RateLimitBelowMinimum",
+    "message": "Rate limit value below protocol minimum"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "build": "tsup src/index.ts src/spl-token.ts --format cjs,esm --dts --clean --external privacycash --external @coral-xyz/anchor",
     "api:baseline:check": "node scripts/check-api-baseline.mjs --check",
     "api:baseline:generate": "node scripts/check-api-baseline.mjs --generate",
+    "errors:check": "node scripts/generate-errors.mjs --check",
+    "errors:generate": "node scripts/generate-errors.mjs",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "prepublishOnly": "npm run build",
     "test:devnet:deep": "AGENC_DEVNET_DRIFT_MODE=compat node scripts/devnet-integration-deep.mjs",

--- a/scripts/generate-errors.mjs
+++ b/scripts/generate-errors.mjs
@@ -1,0 +1,434 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+const SNAPSHOT_PATH = path.join(ROOT_DIR, "data", "coordination-idl-errors.json");
+const OUTPUT_PATH = path.join(ROOT_DIR, "src", "errors.ts");
+
+const ERROR_CATEGORIES = [
+  "agent",
+  "task",
+  "claim",
+  "dispute",
+  "state",
+  "protocol",
+  "general",
+  "rate_limit",
+  "version",
+  "dependency",
+  "nullifier",
+  "cancel",
+  "duplicate",
+  "escrow",
+  "status",
+  "stake",
+  "bond",
+  "reputation",
+  "security",
+  "token",
+  "governance",
+  "skill",
+  "feed",
+];
+
+const CATEGORY_BY_PREFIX = [
+  ["Agent", "agent"],
+  ["Task", "task"],
+  ["Claim", "claim"],
+  ["InvalidProof", "claim"],
+  ["InvalidJournal", "claim"],
+  ["Dispute", "dispute"],
+  ["State", "state"],
+  ["Protocol", "protocol"],
+  ["Multisig", "protocol"],
+  ["ParentTask", "dependency"],
+  ["Nullifier", "nullifier"],
+  ["Bond", "bond"],
+  ["Proposal", "governance"],
+  ["Treasury", "governance"],
+  ["Skill", "skill"],
+  ["Feed", "feed"],
+  ["Reputation", "reputation"],
+  ["Trusted", "claim"],
+  ["Cooldown", "rate_limit"],
+  ["RateLimit", "rate_limit"],
+];
+
+const CATEGORY_BY_NAME = new Map([
+  ["InsufficientCapabilities", "agent"],
+  ["InvalidCapabilities", "agent"],
+  ["MaxActiveTasksReached", "agent"],
+  ["UnauthorizedAgent", "agent"],
+  ["CreatorAuthorityMismatch", "agent"],
+  ["InvalidAgentId", "agent"],
+  ["DeadlinePassed", "task"],
+  ["UnauthorizedTaskAction", "task"],
+  ["InvalidCreator", "task"],
+  ["InvalidTaskId", "task"],
+  ["InvalidDescription", "task"],
+  ["InvalidMaxWorkers", "task"],
+  ["InvalidTaskType", "task"],
+  ["InvalidDeadline", "task"],
+  ["InvalidReward", "task"],
+  ["InvalidRequiredCapabilities", "task"],
+  ["CompetitiveTaskAlreadyWon", "task"],
+  ["NoWorkers", "task"],
+  ["ConstraintHashMismatch", "task"],
+  ["NotPrivateTask", "task"],
+  ["PrivateTaskRequiresZkProof", "task"],
+  ["AlreadyClaimed", "claim"],
+  ["NotClaimed", "claim"],
+  ["GracePeriodNotPassed", "claim"],
+  ["InvalidExpiration", "claim"],
+  ["InvalidProof", "claim"],
+  ["ZkVerificationFailed", "claim"],
+  ["InvalidSealEncoding", "claim"],
+  ["InvalidImageId", "claim"],
+  ["InvalidJournalLength", "claim"],
+  ["InvalidJournalSenderMismatch", "claim"],
+  ["InvalidExpectedSender", "claim"],
+  ["TrustedVerifierProgramMismatch", "claim"],
+  ["RouterAccountMismatch", "claim"],
+  ["InvalidOutputCommitment", "claim"],
+  ["InvalidRentRecipient", "claim"],
+  ["InvalidProofHash", "claim"],
+  ["InvalidResultData", "claim"],
+  ["VotingEnded", "dispute"],
+  ["VotingNotEnded", "dispute"],
+  ["AlreadyVoted", "dispute"],
+  ["NotArbiter", "dispute"],
+  ["InsufficientVotes", "dispute"],
+  ["ActiveDisputeVotes", "dispute"],
+  ["RecentVoteActivity", "dispute"],
+  ["AuthorityAlreadyVoted", "dispute"],
+  ["UnauthorizedResolver", "dispute"],
+  ["InsufficientEvidence", "dispute"],
+  ["EvidenceTooLong", "dispute"],
+  ["SlashAlreadyApplied", "dispute"],
+  ["SlashWindowExpired", "dispute"],
+  ["NotTaskParticipant", "dispute"],
+  ["InvalidEvidenceHash", "dispute"],
+  ["ArbiterIsDisputeParticipant", "dispute"],
+  ["InsufficientQuorum", "dispute"],
+  ["ActiveDisputesExist", "dispute"],
+  ["WorkerAgentRequired", "dispute"],
+  ["WorkerClaimRequired", "dispute"],
+  ["WorkerNotInDispute", "dispute"],
+  ["InitiatorCannotResolve", "dispute"],
+  ["TooManyDisputeVoters", "dispute"],
+  ["VersionMismatch", "state"],
+  ["InvalidStateValue", "state"],
+  ["InvalidStateKey", "state"],
+  ["InvalidInput", "general"],
+  ["ArithmeticOverflow", "general"],
+  ["VoteOverflow", "general"],
+  ["InsufficientFunds", "general"],
+  ["RewardTooSmall", "general"],
+  ["CorruptedData", "general"],
+  ["StringTooLong", "general"],
+  ["InvalidAccountOwner", "general"],
+  ["UpdateTooFrequent", "rate_limit"],
+  ["InvalidCooldown", "rate_limit"],
+  ["InsufficientStakeForDispute", "rate_limit"],
+  ["InsufficientStakeForCreatorDispute", "rate_limit"],
+  ["VersionMismatchProtocol", "version"],
+  ["AccountVersionTooOld", "version"],
+  ["AccountVersionTooNew", "version"],
+  ["InvalidMigrationSource", "version"],
+  ["InvalidMigrationTarget", "version"],
+  ["UnauthorizedUpgrade", "version"],
+  ["InvalidMinVersion", "version"],
+  ["InvalidDependencyType", "dependency"],
+  ["UnauthorizedCreator", "dependency"],
+  ["InvalidNullifier", "nullifier"],
+  ["InsufficientSeedEntropy", "nullifier"],
+  ["IncompleteWorkerAccounts", "cancel"],
+  ["WorkerAccountsRequired", "cancel"],
+  ["DuplicateArbiter", "duplicate"],
+  ["InsufficientEscrowBalance", "escrow"],
+  ["InvalidStatusTransition", "status"],
+  ["InsufficientStake", "protocol"],
+  ["InvalidProtocolFee", "protocol"],
+  ["InvalidDisputeThreshold", "protocol"],
+  ["InvalidTreasury", "protocol"],
+  ["UnauthorizedProtocolAuthority", "protocol"],
+  ["StakeTooLow", "stake"],
+  ["InvalidMinStake", "stake"],
+  ["InvalidSlashAmount", "stake"],
+  ["InsufficientReputation", "reputation"],
+  ["InvalidMinReputation", "reputation"],
+  ["DelegationCooldownNotElapsed", "reputation"],
+  ["DevelopmentKeyNotAllowed", "security"],
+  ["SelfTaskNotAllowed", "security"],
+  ["MissingTokenAccounts", "token"],
+  ["InvalidTokenEscrow", "token"],
+  ["InvalidTokenMint", "token"],
+  ["TokenTransferFailed", "token"],
+  ["InvalidTokenAccountOwner", "token"],
+  ["TimelockNotElapsed", "governance"],
+  ["InvalidProposalPayload", "governance"],
+  ["InvalidProposalType", "governance"],
+  ["InvalidGovernanceParam", "governance"],
+]);
+
+function parseArgs(argv) {
+  const args = {
+    check: false,
+    idlPath: process.env.AGENC_IDL_PATH ?? null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--check") {
+      args.check = true;
+      continue;
+    }
+
+    if (arg === "--idl") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("--idl requires a file path");
+      }
+      args.idlPath = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function normalizeErrors(rawErrors) {
+  if (!Array.isArray(rawErrors) || rawErrors.length === 0) {
+    throw new Error("No IDL errors were found");
+  }
+
+  const normalized = rawErrors.map((entry) => {
+    const code = entry?.code;
+    const name = entry?.name;
+    const message = entry?.message ?? entry?.msg;
+
+    if (!Number.isInteger(code)) {
+      throw new Error(`Invalid error code: ${JSON.stringify(entry)}`);
+    }
+
+    if (typeof name !== "string" || name.length === 0) {
+      throw new Error(`Invalid error name: ${JSON.stringify(entry)}`);
+    }
+
+    if (typeof message !== "string" || message.length === 0) {
+      throw new Error(`Invalid error message: ${JSON.stringify(entry)}`);
+    }
+
+    return { code, name, message };
+  });
+
+  normalized.sort((left, right) => left.code - right.code);
+
+  for (let index = 1; index < normalized.length; index += 1) {
+    if (normalized[index - 1].code === normalized[index].code) {
+      throw new Error(`Duplicate error code ${normalized[index].code}`);
+    }
+  }
+
+  return normalized;
+}
+
+function loadErrors(idlPath) {
+  if (idlPath) {
+    const idl = readJson(path.resolve(idlPath));
+    return normalizeErrors(idl.errors);
+  }
+
+  if (!fs.existsSync(SNAPSHOT_PATH)) {
+    throw new Error(
+      `Missing ${SNAPSHOT_PATH}. Re-run with AGENC_IDL_PATH or --idl to seed the snapshot.`,
+    );
+  }
+
+  return normalizeErrors(readJson(SNAPSHOT_PATH));
+}
+
+function categorizeError(name) {
+  const directCategory = CATEGORY_BY_NAME.get(name);
+  if (directCategory) {
+    return directCategory;
+  }
+
+  for (const [prefix, category] of CATEGORY_BY_PREFIX) {
+    if (name.startsWith(prefix)) {
+      return category;
+    }
+  }
+
+  throw new Error(`No category rule for ${name}`);
+}
+
+function renderErrorEntry(error) {
+  const category = categorizeError(error.name);
+  return `  ${error.code}: {\n    name: ${JSON.stringify(error.name)},\n    message: ${JSON.stringify(error.message)},\n    category: ${JSON.stringify(category)},\n  },`;
+}
+
+function renderErrorsFile(errors) {
+  const minCode = errors[0].code;
+  const maxCode = errors[errors.length - 1].code;
+  const renderedEntries = errors.map(renderErrorEntry).join("\n");
+  const renderedCategories = ERROR_CATEGORIES.map(
+    (category) => `  | ${JSON.stringify(category)}`,
+  ).join("\n");
+
+  return `/**
+ * Full AgenC coordination-program error map (${minCode}-${maxCode}).
+ */
+
+export type ErrorCategory =
+${renderedCategories};
+
+export interface CoordinationErrorEntry {
+  name: string;
+  message: string;
+  category: ErrorCategory;
+}
+
+/**
+ * Complete mapping of on-chain error codes to typed metadata.
+ * Generated from data/coordination-idl-errors.json.
+ * Refresh with AGENC_IDL_PATH=/absolute/path/to/agenc_coordination.json node scripts/generate-errors.mjs
+ */
+export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
+${renderedEntries}
+};
+
+export interface DecodedError extends CoordinationErrorEntry {
+  code: number;
+}
+
+/**
+ * Decode a numeric Anchor error code.
+ */
+export function decodeError(code: number): DecodedError | null {
+  const entry = COORDINATION_ERROR_MAP[code];
+  if (!entry) return null;
+  return { code, ...entry };
+}
+
+function extractCode(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+
+  const err = error as Record<string, unknown>;
+
+  if (typeof err.code === "number") {
+    return err.code;
+  }
+
+  const directErrorCode = err.errorCode as Record<string, unknown> | undefined;
+  if (directErrorCode && typeof directErrorCode.number === "number") {
+    return directErrorCode.number;
+  }
+
+  const nested = err.error as Record<string, unknown> | undefined;
+  const nestedErrorCode = nested?.errorCode as
+    | Record<string, unknown>
+    | undefined;
+  if (nestedErrorCode && typeof nestedErrorCode.number === "number") {
+    return nestedErrorCode.number;
+  }
+
+  if (Array.isArray(err.logs)) {
+    for (const line of err.logs) {
+      if (typeof line !== "string") continue;
+      const match = line.match(/Error Number: (\\d+)/);
+      if (match) return Number.parseInt(match[1], 10);
+    }
+  }
+
+  if (typeof err.message === "string") {
+    const hexMatch = err.message.match(
+      /custom program error: 0x([0-9a-fA-F]+)/,
+    );
+    if (hexMatch) {
+      return Number.parseInt(hexMatch[1], 16);
+    }
+    const decimalMatch = err.message.match(/Error Number: (\\d+)/);
+    if (decimalMatch) {
+      return Number.parseInt(decimalMatch[1], 10);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Decode common Anchor error object shapes.
+ */
+export function decodeAnchorError(error: unknown): DecodedError | null {
+  const code = extractCode(error);
+  if (code === null) return null;
+  return decodeError(code);
+}
+`;
+}
+
+function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+function writeIfChanged(filePath, content) {
+  const normalized = ensureTrailingNewline(content);
+  if (fs.existsSync(filePath)) {
+    const current = fs.readFileSync(filePath, "utf8");
+    if (current === normalized) {
+      return false;
+    }
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, normalized);
+  return true;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const errors = loadErrors(args.idlPath);
+  const snapshotContent = JSON.stringify(errors, null, 2);
+  const errorsFileContent = renderErrorsFile(errors);
+
+  if (args.check) {
+    const expectedSnapshot = ensureTrailingNewline(snapshotContent);
+    const expectedErrorsFile = ensureTrailingNewline(errorsFileContent);
+    const currentSnapshot = fs.existsSync(SNAPSHOT_PATH)
+      ? fs.readFileSync(SNAPSHOT_PATH, "utf8")
+      : null;
+    const currentErrorsFile = fs.existsSync(OUTPUT_PATH)
+      ? fs.readFileSync(OUTPUT_PATH, "utf8")
+      : null;
+
+    if (currentSnapshot !== expectedSnapshot) {
+      throw new Error(
+        "coordination-idl-errors.json is out of date. Re-run node scripts/generate-errors.mjs",
+      );
+    }
+
+    if (currentErrorsFile !== expectedErrorsFile) {
+      throw new Error(
+        "src/errors.ts is out of date. Re-run node scripts/generate-errors.mjs",
+      );
+    }
+
+    return;
+  }
+
+  writeIfChanged(SNAPSHOT_PATH, snapshotContent);
+  writeIfChanged(OUTPUT_PATH, errorsFileContent);
+}
+
+main();

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,7 +1,38 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { decodeAnchorError, decodeError } from "../errors";
+import {
+  COORDINATION_ERROR_MAP,
+  decodeAnchorError,
+  decodeError,
+} from "../errors";
+
+const IDL_ERRORS = JSON.parse(
+  readFileSync(
+    new URL("../../data/coordination-idl-errors.json", import.meta.url),
+    "utf8",
+  ),
+) as Array<{ code: number; name: string; message: string }>;
 
 describe("errors", () => {
+  it("matches the committed protocol error snapshot", () => {
+    expect(IDL_ERRORS).toHaveLength(200);
+    expect(IDL_ERRORS[0]?.code).toBe(6000);
+    expect(IDL_ERRORS.at(-1)?.code).toBe(6199);
+
+    const mapCodes = Object.keys(COORDINATION_ERROR_MAP)
+      .map((code) => Number.parseInt(code, 10))
+      .sort((left, right) => left - right);
+
+    expect(mapCodes).toEqual(IDL_ERRORS.map((entry) => entry.code));
+
+    for (const entry of IDL_ERRORS) {
+      expect(COORDINATION_ERROR_MAP[entry.code]).toMatchObject({
+        name: entry.name,
+        message: entry.message,
+      });
+    }
+  });
+
   it("decodeError returns known coordination errors", () => {
     const decoded = decodeError(6000);
     expect(decoded).not.toBeNull();
@@ -27,9 +58,9 @@ describe("errors", () => {
 
   it("decodeAnchorError handles log/message formats", () => {
     const fromLogs = decodeAnchorError({
-      logs: ["Program log: Error Number: 6050"],
+      logs: ["Program log: Error Number: 6014"],
     });
-    expect(fromLogs?.name).toBe("DisputeNotActive");
+    expect(fromLogs?.name).toBe("TaskNotOpen");
 
     const fromHex = decodeAnchorError({
       message: "custom program error: 0x1770",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Full AgenC coordination-program error map (6000-6160).
+ * Full AgenC coordination-program error map (6000-6199).
  */
 
 export type ErrorCategory =
@@ -23,7 +23,9 @@ export type ErrorCategory =
   | "reputation"
   | "security"
   | "token"
-  | "governance";
+  | "governance"
+  | "skill"
+  | "feed";
 
 export interface CoordinationErrorEntry {
   name: string;
@@ -33,7 +35,8 @@ export interface CoordinationErrorEntry {
 
 /**
  * Complete mapping of on-chain error codes to typed metadata.
- * Generated from target/idl/agenc_coordination.json.
+ * Generated from data/coordination-idl-errors.json.
+ * Refresh with AGENC_IDL_PATH=/absolute/path/to/agenc_coordination.json node scripts/generate-errors.mjs
  */
 export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
   6000: {
@@ -101,7 +104,11 @@ export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
     message: "Agent cannot set status to Active while having active tasks",
     category: "agent",
   },
-  6013: { name: "TaskNotFound", message: "Task not found", category: "task" },
+  6013: {
+    name: "TaskNotFound",
+    message: "Task not found",
+    category: "task",
+  },
   6014: {
     name: "TaskNotOpen",
     message: "Task is not open for claims",
@@ -112,7 +119,11 @@ export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
     message: "Task has reached maximum workers",
     category: "task",
   },
-  6016: { name: "TaskExpired", message: "Task has expired", category: "task" },
+  6016: {
+    name: "TaskExpired",
+    message: "Task has expired",
+    category: "task",
+  },
   6017: {
     name: "TaskNotExpired",
     message: "Task deadline has not passed",
@@ -180,8 +191,7 @@ export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
   },
   6030: {
     name: "InvalidRequiredCapabilities",
-    message:
-      "Invalid required capabilities: required_capabilities cannot be zero",
+    message: "Invalid required capabilities: required_capabilities cannot be zero",
     category: "task",
   },
   6031: {
@@ -189,11 +199,14 @@ export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
     message: "Competitive task already completed by another worker",
     category: "task",
   },
-  6032: { name: "NoWorkers", message: "Task has no workers", category: "task" },
+  6032: {
+    name: "NoWorkers",
+    message: "Task has no workers",
+    category: "task",
+  },
   6033: {
     name: "ConstraintHashMismatch",
-    message:
-      "Proof constraint hash does not match task's stored constraint hash",
+    message: "Proof constraint hash does not match task's stored constraint hash",
     category: "task",
   },
   6034: {
@@ -242,603 +255,789 @@ export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
     category: "claim",
   },
   6043: {
+    name: "InvalidSealEncoding",
+    message: "Invalid RISC0 seal encoding",
+    category: "claim",
+  },
+  6044: {
+    name: "InvalidJournalLength",
+    message: "Invalid RISC0 journal length",
+    category: "claim",
+  },
+  6045: {
+    name: "InvalidJournalBinding",
+    message: "Invalid RISC0 journal binding",
+    category: "claim",
+  },
+  6046: {
+    name: "InvalidJournalTask",
+    message: "RISC0 journal task binding mismatch",
+    category: "claim",
+  },
+  6047: {
+    name: "InvalidJournalAuthority",
+    message: "RISC0 journal authority binding mismatch",
+    category: "claim",
+  },
+  6048: {
+    name: "InvalidImageId",
+    message: "Invalid RISC0 image ID",
+    category: "claim",
+  },
+  6049: {
+    name: "TrustedSelectorMismatch",
+    message: "RISC0 seal selector does not match trusted selector",
+    category: "claim",
+  },
+  6050: {
+    name: "TrustedVerifierProgramMismatch",
+    message: "RISC0 verifier program does not match trusted verifier",
+    category: "claim",
+  },
+  6051: {
+    name: "RouterAccountMismatch",
+    message: "RISC0 router account constraints failed",
+    category: "claim",
+  },
+  6052: {
     name: "InvalidProofSize",
     message: "Invalid proof size - expected 256 bytes for RISC Zero seal body",
     category: "claim",
   },
-  6044: {
+  6053: {
     name: "InvalidProofBinding",
     message: "Invalid proof binding: expected_binding cannot be all zeros",
     category: "claim",
   },
-  6045: {
+  6054: {
     name: "InvalidOutputCommitment",
     message: "Invalid output commitment: output_commitment cannot be all zeros",
     category: "claim",
   },
-  6046: {
+  6055: {
     name: "InvalidRentRecipient",
     message: "Invalid rent recipient: must be worker authority",
     category: "claim",
   },
-  6047: {
+  6056: {
     name: "GracePeriodNotPassed",
-    message:
-      "Grace period not passed: only worker authority can expire claim within 60 seconds of expiry",
+    message: "Grace period not passed: only worker authority can expire claim within 60 seconds of expiry",
     category: "claim",
   },
-  6048: {
+  6057: {
     name: "InvalidProofHash",
     message: "Invalid proof hash: proof_hash cannot be all zeros",
     category: "claim",
   },
-  6049: {
+  6058: {
     name: "InvalidResultData",
-    message:
-      "Invalid result data: result_data cannot be all zeros when provided",
+    message: "Invalid result data: result_data cannot be all zeros when provided",
     category: "claim",
   },
-  6050: {
+  6059: {
     name: "DisputeNotActive",
     message: "Dispute is not active",
     category: "dispute",
   },
-  6051: {
+  6060: {
     name: "VotingEnded",
     message: "Voting period has ended",
     category: "dispute",
   },
-  6052: {
+  6061: {
     name: "VotingNotEnded",
     message: "Voting period has not ended",
     category: "dispute",
   },
-  6053: {
+  6062: {
     name: "AlreadyVoted",
     message: "Already voted on this dispute",
     category: "dispute",
   },
-  6054: {
+  6063: {
     name: "NotArbiter",
     message: "Not authorized to vote (not an arbiter)",
     category: "dispute",
   },
-  6055: {
+  6064: {
     name: "InsufficientVotes",
     message: "Insufficient votes to resolve",
     category: "dispute",
   },
-  6056: {
+  6065: {
     name: "DisputeAlreadyResolved",
     message: "Dispute has already been resolved",
     category: "dispute",
   },
-  6057: {
+  6066: {
     name: "UnauthorizedResolver",
-    message:
-      "Only protocol authority or dispute initiator can resolve disputes",
+    message: "Only protocol authority or dispute initiator can resolve disputes",
     category: "dispute",
   },
-  6058: {
+  6067: {
     name: "ActiveDisputeVotes",
     message: "Agent has active dispute votes pending resolution",
     category: "dispute",
   },
-  6059: {
+  6068: {
     name: "RecentVoteActivity",
     message: "Agent must wait 24 hours after voting before deregistering",
     category: "dispute",
   },
-  6060: {
+  6069: {
     name: "AuthorityAlreadyVoted",
     message: "Authority has already voted on this dispute",
     category: "dispute",
   },
-  6061: {
+  6070: {
     name: "InsufficientEvidence",
     message: "Insufficient dispute evidence provided",
     category: "dispute",
   },
-  6062: {
+  6071: {
     name: "EvidenceTooLong",
     message: "Dispute evidence exceeds maximum allowed length",
     category: "dispute",
   },
-  6063: {
+  6072: {
     name: "DisputeNotExpired",
     message: "Dispute has not expired",
     category: "dispute",
   },
-  6064: {
+  6073: {
     name: "SlashAlreadyApplied",
     message: "Dispute slashing already applied",
     category: "dispute",
   },
-  6065: {
+  6074: {
     name: "SlashWindowExpired",
-    message:
-      "Slash window expired: must apply slashing within 7 days of resolution",
+    message: "Slash window expired: must apply slashing within 7 days of resolution",
     category: "dispute",
   },
-  6066: {
+  6075: {
     name: "DisputeNotResolved",
     message: "Dispute has not been resolved",
     category: "dispute",
   },
-  6067: {
+  6076: {
     name: "NotTaskParticipant",
     message: "Only task creator or workers can initiate disputes",
     category: "dispute",
   },
-  6068: {
+  6077: {
     name: "InvalidEvidenceHash",
     message: "Invalid evidence hash: cannot be all zeros",
     category: "dispute",
   },
-  6069: {
+  6078: {
     name: "ArbiterIsDisputeParticipant",
     message: "Arbiter cannot vote on disputes they are a participant in",
     category: "dispute",
   },
-  6070: {
+  6079: {
     name: "InsufficientQuorum",
     message: "Insufficient quorum: minimum number of voters not reached",
     category: "dispute",
   },
-  6071: {
+  6080: {
     name: "ActiveDisputesExist",
     message: "Agent has active disputes as defendant and cannot deregister",
     category: "dispute",
   },
-  6072: {
+  6081: {
+    name: "TooManyDisputeVoters",
+    message: "Dispute has reached maximum voter capacity",
+    category: "dispute",
+  },
+  6082: {
     name: "WorkerAgentRequired",
     message: "Worker agent account required when creator initiates dispute",
     category: "dispute",
   },
-  6073: {
+  6083: {
     name: "WorkerClaimRequired",
     message: "Worker claim account required when creator initiates dispute",
     category: "dispute",
   },
-  6074: {
+  6084: {
     name: "WorkerNotInDispute",
     message: "Worker was not involved in this dispute",
     category: "dispute",
   },
-  6075: {
+  6085: {
     name: "InitiatorCannotResolve",
     message: "Dispute initiator cannot resolve their own dispute",
     category: "dispute",
   },
-  6076: {
+  6086: {
     name: "VersionMismatch",
     message: "State version mismatch (concurrent modification)",
     category: "state",
   },
-  6077: {
+  6087: {
     name: "StateKeyExists",
     message: "State key already exists",
     category: "state",
   },
-  6078: {
+  6088: {
     name: "StateNotFound",
     message: "State not found",
     category: "state",
   },
-  6079: {
+  6089: {
     name: "InvalidStateValue",
     message: "Invalid state value: state_value cannot be all zeros",
     category: "state",
   },
-  6080: {
+  6090: {
     name: "StateOwnershipViolation",
-    message:
-      "State ownership violation: only the creator agent can update this state",
+    message: "State ownership violation: only the creator agent can update this state",
     category: "state",
   },
-  6081: {
+  6091: {
     name: "InvalidStateKey",
     message: "Invalid state key: state_key cannot be all zeros",
     category: "state",
   },
-  6082: {
+  6092: {
     name: "ProtocolAlreadyInitialized",
     message: "Protocol is already initialized",
     category: "protocol",
   },
-  6083: {
+  6093: {
     name: "ProtocolNotInitialized",
     message: "Protocol is not initialized",
     category: "protocol",
   },
-  6084: {
+  6094: {
     name: "InvalidProtocolFee",
     message: "Invalid protocol fee (must be <= 1000 bps)",
     category: "protocol",
   },
-  6085: {
+  6095: {
     name: "InvalidTreasury",
     message: "Invalid treasury: treasury account cannot be default pubkey",
     category: "protocol",
   },
-  6086: {
+  6096: {
     name: "InvalidDisputeThreshold",
-    message:
-      "Invalid dispute threshold: must be 1-100 (percentage of votes required)",
+    message: "Invalid dispute threshold: must be 1-100 (percentage of votes required)",
     category: "protocol",
   },
-  6087: {
+  6097: {
     name: "InsufficientStake",
     message: "Insufficient stake for arbiter registration",
     category: "protocol",
   },
-  6088: {
+  6098: {
     name: "MultisigInvalidThreshold",
     message: "Invalid multisig threshold",
     category: "protocol",
   },
-  6089: {
+  6099: {
     name: "MultisigInvalidSigners",
     message: "Invalid multisig signer configuration",
     category: "protocol",
   },
-  6090: {
+  6100: {
     name: "MultisigNotEnoughSigners",
     message: "Not enough multisig signers",
     category: "protocol",
   },
-  6091: {
+  6101: {
     name: "MultisigDuplicateSigner",
     message: "Duplicate multisig signer provided",
     category: "protocol",
   },
-  6092: {
+  6102: {
     name: "MultisigDefaultSigner",
     message: "Multisig signer cannot be default pubkey",
     category: "protocol",
   },
-  6093: {
+  6103: {
     name: "MultisigSignerNotSystemOwned",
     message: "Multisig signer account not owned by System Program",
     category: "protocol",
   },
-  6094: {
+  6104: {
     name: "InvalidInput",
     message: "Invalid input parameter",
     category: "general",
   },
-  6095: {
+  6105: {
     name: "ArithmeticOverflow",
     message: "Arithmetic overflow",
     category: "general",
   },
-  6096: {
+  6106: {
     name: "VoteOverflow",
     message: "Vote count overflow",
     category: "general",
   },
-  6097: {
+  6107: {
     name: "InsufficientFunds",
     message: "Insufficient funds",
     category: "general",
   },
-  6098: {
+  6108: {
     name: "RewardTooSmall",
     message: "Reward too small: worker must receive at least 1 lamport",
     category: "general",
   },
-  6099: {
+  6109: {
     name: "CorruptedData",
     message: "Account data is corrupted",
     category: "general",
   },
-  6100: {
+  6110: {
     name: "StringTooLong",
     message: "String too long",
     category: "general",
   },
-  6101: {
+  6111: {
     name: "InvalidAccountOwner",
-    message:
-      "Account owner validation failed: account not owned by this program",
+    message: "Account owner validation failed: account not owned by this program",
     category: "general",
   },
-  6102: {
+  6112: {
     name: "RateLimitExceeded",
     message: "Rate limit exceeded: maximum actions per 24h window reached",
     category: "rate_limit",
   },
-  6103: {
+  6113: {
     name: "CooldownNotElapsed",
     message: "Cooldown period has not elapsed since last action",
     category: "rate_limit",
   },
-  6104: {
+  6114: {
     name: "UpdateTooFrequent",
     message: "Agent update too frequent: must wait cooldown period",
     category: "rate_limit",
   },
-  6105: {
+  6115: {
     name: "InvalidCooldown",
     message: "Cooldown value cannot be negative",
     category: "rate_limit",
   },
-  6106: {
+  6116: {
     name: "CooldownTooLarge",
     message: "Cooldown value exceeds maximum (24 hours)",
     category: "rate_limit",
   },
-  6107: {
+  6117: {
     name: "RateLimitTooHigh",
     message: "Rate limit value exceeds maximum allowed (1000)",
     category: "rate_limit",
   },
-  6108: {
+  6118: {
     name: "CooldownTooLong",
     message: "Cooldown value exceeds maximum allowed (1 week)",
     category: "rate_limit",
   },
-  6109: {
+  6119: {
     name: "InsufficientStakeForDispute",
     message: "Insufficient stake to initiate dispute",
     category: "rate_limit",
   },
-  6110: {
+  6120: {
     name: "InsufficientStakeForCreatorDispute",
     message: "Creator-initiated disputes require 2x the minimum stake",
     category: "rate_limit",
   },
-  6111: {
+  6121: {
     name: "VersionMismatchProtocol",
-    message:
-      "Protocol version mismatch: account version incompatible with current program",
+    message: "Protocol version mismatch: account version incompatible with current program",
     category: "version",
   },
-  6112: {
+  6122: {
     name: "AccountVersionTooOld",
     message: "Account version too old: migration required",
     category: "version",
   },
-  6113: {
+  6123: {
     name: "AccountVersionTooNew",
     message: "Account version too new: program upgrade required",
     category: "version",
   },
-  6114: {
+  6124: {
     name: "InvalidMigrationSource",
     message: "Migration not allowed: invalid source version",
     category: "version",
   },
-  6115: {
+  6125: {
     name: "InvalidMigrationTarget",
     message: "Migration not allowed: invalid target version",
     category: "version",
   },
-  6116: {
+  6126: {
     name: "UnauthorizedUpgrade",
     message: "Only upgrade authority can perform this action",
     category: "version",
   },
-  6117: {
+  6127: {
+    name: "UnauthorizedProtocolAuthority",
+    message: "Only protocol authority can perform this action",
+    category: "protocol",
+  },
+  6128: {
     name: "InvalidMinVersion",
     message: "Minimum version cannot exceed current protocol version",
     category: "version",
   },
-  6118: {
+  6129: {
     name: "ProtocolConfigRequired",
-    message:
-      "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts",
-    category: "version",
+    message: "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts",
+    category: "protocol",
   },
-  6119: {
+  6130: {
     name: "ParentTaskCancelled",
     message: "Parent task has been cancelled",
     category: "dependency",
   },
-  6120: {
+  6131: {
     name: "ParentTaskDisputed",
     message: "Parent task is in disputed state",
     category: "dependency",
   },
-  6121: {
+  6132: {
     name: "InvalidDependencyType",
     message: "Invalid dependency type",
     category: "dependency",
   },
-  6122: {
+  6133: {
     name: "ParentTaskNotCompleted",
-    message:
-      "Parent task must be completed before completing a proof-dependent task",
+    message: "Parent task must be completed before completing a proof-dependent task",
     category: "dependency",
   },
-  6123: {
+  6134: {
     name: "ParentTaskAccountRequired",
     message: "Parent task account required for proof-dependent task completion",
     category: "dependency",
   },
-  6124: {
+  6135: {
     name: "UnauthorizedCreator",
     message: "Parent task does not belong to the same creator",
     category: "dependency",
   },
-  6125: {
+  6136: {
     name: "NullifierAlreadySpent",
-    message:
-      "Nullifier has already been spent - proof/knowledge reuse detected",
+    message: "Nullifier has already been spent - proof/knowledge reuse detected",
     category: "nullifier",
   },
-  6126: {
+  6137: {
     name: "InvalidNullifier",
     message: "Invalid nullifier: nullifier value cannot be all zeros",
     category: "nullifier",
   },
-  6127: {
+  6138: {
     name: "IncompleteWorkerAccounts",
-    message:
-      "All worker accounts must be provided when cancelling a task with active claims",
+    message: "All worker accounts must be provided when cancelling a task with active claims",
     category: "cancel",
   },
-  6128: {
+  6139: {
     name: "WorkerAccountsRequired",
     message: "Worker accounts required when task has active workers",
     category: "cancel",
   },
-  6129: {
+  6140: {
     name: "DuplicateArbiter",
     message: "Duplicate arbiter provided in remaining_accounts",
     category: "duplicate",
   },
-  6130: {
+  6141: {
     name: "InsufficientEscrowBalance",
     message: "Escrow has insufficient balance for reward transfer",
     category: "escrow",
   },
-  6131: {
+  6142: {
     name: "InvalidStatusTransition",
     message: "Invalid task status transition",
     category: "status",
   },
-  6132: {
+  6143: {
     name: "StakeTooLow",
     message: "Stake value is below minimum required (0.001 SOL)",
     category: "stake",
   },
-  6133: {
+  6144: {
     name: "InvalidMinStake",
     message: "min_stake_for_dispute must be greater than zero",
     category: "stake",
   },
-  6134: {
+  6145: {
     name: "InvalidSlashAmount",
     message: "Slash amount must be greater than zero",
     category: "stake",
   },
-  6135: {
+  6146: {
     name: "BondAmountTooLow",
     message: "Bond amount too low",
     category: "bond",
   },
-  6136: {
+  6147: {
     name: "BondAlreadyExists",
     message: "Bond already exists",
     category: "bond",
   },
-  6137: { name: "BondNotFound", message: "Bond not found", category: "bond" },
-  6138: {
+  6148: {
+    name: "BondNotFound",
+    message: "Bond not found",
+    category: "bond",
+  },
+  6149: {
     name: "BondNotMatured",
     message: "Bond not yet matured",
     category: "bond",
   },
-  6139: {
+  6150: {
     name: "InsufficientReputation",
     message: "Agent reputation below task minimum requirement",
     category: "reputation",
   },
-  6140: {
+  6151: {
     name: "InvalidMinReputation",
     message: "Invalid minimum reputation: must be <= 10000",
     category: "reputation",
   },
-  6141: {
+  6152: {
     name: "DevelopmentKeyNotAllowed",
-    message:
-      "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use.",
+    message: "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use.",
     category: "security",
   },
-  6142: {
+  6153: {
     name: "SelfTaskNotAllowed",
     message: "Cannot claim own task: worker authority matches task creator",
     category: "security",
   },
-  6143: {
+  6154: {
     name: "MissingTokenAccounts",
     message: "Token accounts not provided for token-denominated task",
     category: "token",
   },
-  6144: {
+  6155: {
     name: "InvalidTokenEscrow",
     message: "Token escrow ATA does not match expected derivation",
     category: "token",
   },
-  6145: {
+  6156: {
     name: "InvalidTokenMint",
     message: "Provided mint does not match task's reward_mint",
     category: "token",
   },
-  6146: {
+  6157: {
     name: "TokenTransferFailed",
     message: "SPL token transfer CPI failed",
     category: "token",
   },
-  6147: {
+  6158: {
     name: "ProposalNotActive",
     message: "Proposal is not active",
     category: "governance",
   },
-  6148: {
+  6159: {
     name: "ProposalVotingNotEnded",
     message: "Voting period has not ended",
     category: "governance",
   },
-  6149: {
+  6160: {
     name: "ProposalVotingEnded",
     message: "Voting period has ended",
     category: "governance",
   },
-  6150: {
+  6161: {
     name: "ProposalAlreadyExecuted",
     message: "Proposal has already been executed",
     category: "governance",
   },
-  6151: {
+  6162: {
     name: "ProposalInsufficientQuorum",
     message: "Insufficient quorum for proposal execution",
     category: "governance",
   },
-  6152: {
+  6163: {
     name: "ProposalNotApproved",
     message: "Proposal did not achieve majority",
     category: "governance",
   },
-  6153: {
+  6164: {
     name: "ProposalUnauthorizedCancel",
     message: "Only the proposer can cancel this proposal",
     category: "governance",
   },
-  6154: {
+  6165: {
     name: "ProposalInsufficientStake",
     message: "Insufficient stake to create a proposal",
     category: "governance",
   },
-  6155: {
+  6166: {
     name: "InvalidProposalPayload",
     message: "Invalid proposal payload",
     category: "governance",
   },
-  6156: {
+  6167: {
     name: "InvalidProposalType",
     message: "Invalid proposal type",
     category: "governance",
   },
-  6157: {
+  6168: {
     name: "TreasuryInsufficientBalance",
     message: "Treasury spend amount exceeds available balance",
     category: "governance",
   },
-  6158: {
+  6169: {
     name: "TimelockNotElapsed",
     message: "Execution timelock has not elapsed",
     category: "governance",
   },
-  6159: {
+  6170: {
     name: "InvalidGovernanceParam",
     message: "Invalid governance configuration parameter",
     category: "governance",
   },
-  6160: {
+  6171: {
     name: "TreasuryNotProgramOwned",
     message: "Treasury must be a program-owned PDA",
     category: "governance",
+  },
+  6172: {
+    name: "TreasuryNotSpendable",
+    message: "Treasury must be program-owned, or a signer system account for governance spends",
+    category: "governance",
+  },
+  6173: {
+    name: "SkillInvalidId",
+    message: "Skill ID cannot be all zeros",
+    category: "skill",
+  },
+  6174: {
+    name: "SkillInvalidName",
+    message: "Skill name cannot be all zeros",
+    category: "skill",
+  },
+  6175: {
+    name: "SkillInvalidContentHash",
+    message: "Skill content hash cannot be all zeros",
+    category: "skill",
+  },
+  6176: {
+    name: "SkillNotActive",
+    message: "Skill is not active",
+    category: "skill",
+  },
+  6177: {
+    name: "SkillInvalidRating",
+    message: "Rating must be between 1 and 5",
+    category: "skill",
+  },
+  6178: {
+    name: "SkillSelfRating",
+    message: "Cannot rate own skill",
+    category: "skill",
+  },
+  6179: {
+    name: "SkillUnauthorizedUpdate",
+    message: "Only the skill author can update this skill",
+    category: "skill",
+  },
+  6180: {
+    name: "SkillSelfPurchase",
+    message: "Cannot purchase own skill",
+    category: "skill",
+  },
+  6181: {
+    name: "FeedInvalidContentHash",
+    message: "Feed content hash cannot be all zeros",
+    category: "feed",
+  },
+  6182: {
+    name: "FeedInvalidTopic",
+    message: "Feed topic cannot be all zeros",
+    category: "feed",
+  },
+  6183: {
+    name: "FeedPostNotFound",
+    message: "Feed post not found",
+    category: "feed",
+  },
+  6184: {
+    name: "FeedSelfUpvote",
+    message: "Cannot upvote own post",
+    category: "feed",
+  },
+  6185: {
+    name: "ReputationStakeAmountTooLow",
+    message: "Reputation stake amount must be greater than zero",
+    category: "reputation",
+  },
+  6186: {
+    name: "ReputationStakeLocked",
+    message: "Reputation stake is locked: withdrawal before cooldown",
+    category: "reputation",
+  },
+  6187: {
+    name: "ReputationStakeInsufficientBalance",
+    message: "Reputation stake has insufficient balance for withdrawal",
+    category: "reputation",
+  },
+  6188: {
+    name: "ReputationDelegationAmountInvalid",
+    message: "Reputation delegation amount invalid: must be > 0, <= 10000, and >= MIN_DELEGATION_AMOUNT",
+    category: "reputation",
+  },
+  6189: {
+    name: "ReputationCannotDelegateSelf",
+    message: "Cannot delegate reputation to self",
+    category: "reputation",
+  },
+  6190: {
+    name: "ReputationDelegationExpired",
+    message: "Reputation delegation has expired",
+    category: "reputation",
+  },
+  6191: {
+    name: "ReputationAgentNotActive",
+    message: "Agent must be Active to participate in reputation economy",
+    category: "reputation",
+  },
+  6192: {
+    name: "ReputationDisputesPending",
+    message: "Agent has pending disputes as defendant: cannot withdraw stake",
+    category: "reputation",
+  },
+  6193: {
+    name: "PrivateTaskRequiresZkProof",
+    message: "Private tasks (non-zero constraint_hash) must use complete_task_private",
+    category: "task",
+  },
+  6194: {
+    name: "InvalidTokenAccountOwner",
+    message: "Token account owner does not match expected authority",
+    category: "token",
+  },
+  6195: {
+    name: "InsufficientSeedEntropy",
+    message: "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)",
+    category: "nullifier",
+  },
+  6196: {
+    name: "SkillPriceBelowMinimum",
+    message: "Skill price below minimum required",
+    category: "skill",
+  },
+  6197: {
+    name: "SkillPriceChanged",
+    message: "Skill price changed since transaction was prepared",
+    category: "skill",
+  },
+  6198: {
+    name: "DelegationCooldownNotElapsed",
+    message: "Delegation must be active for minimum duration before revocation",
+    category: "reputation",
+  },
+  6199: {
+    name: "RateLimitBelowMinimum",
+    message: "Rate limit value below protocol minimum",
+    category: "rate_limit",
   },
 };
 


### PR DESCRIPTION
## Summary
- regenerate `src/errors.ts` from a committed protocol IDL error snapshot covering codes `6000-6199`
- add `scripts/generate-errors.mjs` plus `errors:generate` / `errors:check` scripts for deterministic refreshes
- guard the map with a snapshot-backed test so drift is caught in this repo

Closes #6
