### PR TITLE
fix(errors): prefer Anchor named errors over stale codes

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -72,11 +72,27 @@ describe("errors", () => {
   it("decodes protocol InsufficientStake with the current devnet/program IDL code", () => {
     const decoded = decodeAnchorError({
       message:
-        "AnchorError thrown in src/instructions/register_agent.rs:69. Error Code: InsufficientStake. Error Number: 6127. Error Message: Insufficient stake for arbiter registration.",
+        "AnchorError thrown in src/instructions/register_agent.rs:69. Error Code: InsufficientStake. Error Number: 6135. Error Message: Insufficient stake for arbiter registration.",
     });
 
     expect(decoded).not.toBeNull();
     expect(decoded?.name).toBe("InsufficientStake");
-    expect(decoded?.message).toBe("Insufficient stake for arbiter registration");
+    expect(decoded?.message).toBe(
+      "Insufficient stake for arbiter registration.",
+    );
+  });
+
+  it("prefers Anchor's named error over a stale numeric mapping", () => {
+    const decoded = decodeAnchorError({
+      logs: [
+        "Program log: AnchorError thrown in src/instructions/register_agent.rs:69. Error Code: InsufficientStake. Error Number: 6135. Error Message: Insufficient stake for arbiter registration.",
+      ],
+      message: "custom program error: 0x17f7",
+    });
+
+    expect(decoded).not.toBeNull();
+    expect(decoded?.code).toBe(6135);
+    expect(decoded?.name).toBe("InsufficientStake");
+    expect(decoded?.message).toBe("Insufficient stake for arbiter registration.");
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1195,6 +1195,11 @@ export interface DecodedError extends CoordinationErrorEntry {
   code: number;
 }
 
+const COORDINATION_ERROR_NAME_MAP: Record<string, CoordinationErrorEntry> =
+  Object.fromEntries(
+    Object.values(COORDINATION_ERROR_MAP).map((entry) => [entry.name, entry]),
+  );
+
 /**
  * Decode a numeric Anchor error code.
  */
@@ -1250,10 +1255,54 @@ function extractCode(error: unknown): number | null {
   return null;
 }
 
+function extractNamedAnchorError(
+  error: unknown,
+): Pick<DecodedError, "code" | "name" | "message" | "category"> | null {
+  if (!error || typeof error !== "object") return null;
+
+  const err = error as Record<string, unknown>;
+  const candidates = [
+    ...(Array.isArray(err.logs) ? err.logs.filter((line) => typeof line === "string") : []),
+    ...(Array.isArray(err.errorLogs)
+      ? err.errorLogs.filter((line) => typeof line === "string")
+      : []),
+    ...(typeof err.message === "string" ? [err.message] : []),
+  ];
+
+  for (const candidate of candidates) {
+    const match = candidate.match(
+      /Error Code: ([A-Za-z0-9_]+)\. Error Number: (\d+)\. Error Message: (.+)/,
+    );
+    if (!match) {
+      continue;
+    }
+
+    const [, name, numericCode, message] = match;
+    const entry = COORDINATION_ERROR_NAME_MAP[name];
+    if (!entry) {
+      continue;
+    }
+
+    return {
+      code: Number.parseInt(numericCode, 10),
+      name: entry.name,
+      message,
+      category: entry.category,
+    };
+  }
+
+  return null;
+}
+
 /**
  * Decode common Anchor error object shapes.
  */
 export function decodeAnchorError(error: unknown): DecodedError | null {
+  const named = extractNamedAnchorError(error);
+  if (named) {
+    return named;
+  }
+
   const code = extractCode(error);
   if (code === null) return null;
   return decodeError(code);


### PR DESCRIPTION
## Summary
- prefer `decodeAnchorError` to use Anchor named errors from logs and messages before stale numeric code mappings
- keep SDK error decoding aligned with observed devnet behavior when Anchor error numbers drift
- add regression coverage for the `InsufficientStake` case seen during strict devnet validation

## Verification
- `npm test -- --run src/__tests__/errors.test.ts`
