### PR TITLE
fix: require explicit protocol IDL for devnet task validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ Funding notes:
 - `test:devnet:reputation`: the delegator needs agent stake plus
   `AGENC_REPUTATION_STAKE_LAMPORTS`; the delegatee needs enough SOL to register.
 
+### Public task flow
+
+```bash
+CREATOR_WALLET=/path/to/creator.json \
+WORKER_WALLET=/path/to/worker.json \
+npm run test:devnet:public
+```
+
+This validates the happy-path public lifecycle `register -> create -> claim -> complete`.
+`AGENC_IDL_PATH` must be set explicitly so the validator runs against the intended
+protocol build instead of a machine-local fallback.
+
 ### Deep public task flow
 
 ```bash

--- a/scripts/devnet-integration-deep.mjs
+++ b/scripts/devnet-integration-deep.mjs
@@ -6,11 +6,9 @@ import crypto from "node:crypto";
 import { Connection, Keypair } from "@solana/web3.js";
 import { AnchorProvider, Program } from "@coral-xyz/anchor";
 import * as sdk from "../dist/index.mjs";
+import { resolveIdlPath } from "./devnet-helpers.mjs";
 
 const DEFAULT_RPC_URL = process.env.AGENC_RPC_URL ?? sdk.DEVNET_RPC;
-const DEFAULT_IDL_PATH =
-  process.env.AGENC_IDL_PATH ??
-  "/Users/pchmirenko/AgenC-pr1469-fix/runtime/idl/agenc_coordination.json";
 const DEFAULT_COMMITMENT = "confirmed";
 const DEFAULT_ENDPOINT = "https://example.invalid/agenc-devnet-deep-test";
 const DEFAULT_REWARD = 10_000_000n;
@@ -30,7 +28,7 @@ Environment:
   CREATOR_WALLET          Required
   WORKER_WALLET           Required
   AGENC_RPC_URL           Optional (default: ${DEFAULT_RPC_URL})
-  AGENC_IDL_PATH          Optional (default: ${DEFAULT_IDL_PATH})
+  AGENC_IDL_PATH          Required. Path to agenc_coordination.json
   AGENC_DEVNET_DRIFT_MODE Optional: compat|strict (default: ${DEFAULT_DRIFT_MODE})
 `);
 }
@@ -199,10 +197,11 @@ async function main() {
 
   const creatorWalletPath = env("CREATOR_WALLET");
   const workerWalletPath = env("WORKER_WALLET");
+  const idlPath = resolveIdlPath();
   const [creator, worker, idl] = await Promise.all([
     loadKeypair(creatorWalletPath),
     loadKeypair(workerWalletPath),
-    loadJson(DEFAULT_IDL_PATH),
+    loadJson(idlPath),
   ]);
 
   if (creator.publicKey.equals(worker.publicKey)) {

--- a/scripts/devnet-integration.mjs
+++ b/scripts/devnet-integration.mjs
@@ -6,12 +6,12 @@ import crypto from "node:crypto";
 import { Connection, Keypair } from "@solana/web3.js";
 import { AnchorProvider, Program } from "@coral-xyz/anchor";
 import * as sdk from "../dist/index.mjs";
+import { resolveIdlPath } from "./devnet-helpers.mjs";
 
 const DEFAULT_RPC_URL = process.env.AGENC_RPC_URL ?? sdk.DEVNET_RPC;
 const DEFAULT_COMMITMENT = "confirmed";
 const DEFAULT_REWARD_LAMPORTS = 10_000_000n; // 0.01 SOL
 const DEFAULT_AGENT_ENDPOINT = "https://example.invalid/agenc-devnet-test";
-const DEFAULT_IDL_PATH = "/Users/pchmirenko/AgenC-pr1469-fix/runtime/idl/agenc_coordination.json";
 
 function usage() {
   process.stdout.write(`Usage:
@@ -22,7 +22,7 @@ Environment:
   WORKER_WALLET           Required. Solana keypair JSON for task worker.
   AGENC_RPC_URL           Optional. Defaults to ${DEFAULT_RPC_URL}
   AGENC_REWARD_LAMPORTS   Optional. Defaults to ${DEFAULT_REWARD_LAMPORTS.toString()}
-  AGENC_IDL_PATH          Optional. Defaults to ${DEFAULT_IDL_PATH}
+  AGENC_IDL_PATH          Required. Path to agenc_coordination.json
 
 What this validates:
   1. Reads protocol config from devnet
@@ -126,7 +126,7 @@ async function main() {
   const rewardLamports = BigInt(
     process.env.AGENC_REWARD_LAMPORTS ?? DEFAULT_REWARD_LAMPORTS.toString(),
   );
-  const idlPath = process.env.AGENC_IDL_PATH ?? DEFAULT_IDL_PATH;
+  const idlPath = resolveIdlPath();
 
   console.log(`[config] rpc: ${rpcUrl}`);
   console.log(`[config] creator wallet: ${creatorWalletPath}`);

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import {
   createTask,
   claimTask,
@@ -104,6 +104,17 @@ describe("SDK contract tests", () => {
     expect(result).toHaveProperty("txSignature", "tx-create-task");
     expect(typeof result.txSignature).toBe("string");
     expect(result.txSignature).toBe("tx-create-task");
+
+    const builder = (program as any).methods.createTask.mock.results[0].value;
+    expect(builder.accountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: result.taskPda,
+        creator: creator.publicKey,
+        authority: creator.publicKey,
+        systemProgram: SystemProgram.programId,
+      }),
+    );
+    expect(builder.signers).toHaveBeenCalledWith([creator]);
   });
 
   it("returns stable contract for configureTaskValidation", async () => {


### PR DESCRIPTION
## Summary
- remove machine-local IDL fallbacks from the public and deep devnet task validators
- require `AGENC_IDL_PATH` explicitly so fresh-clone runs target the intended protocol build
- add a contract assertion that `createTask` still signs with the creator
- document the public devnet task flow in the README

Closes #23.

## Verification
- `npm run build`
- `npm run typecheck`
- `npm exec -- vitest run src/__tests__/contract.test.ts`
- `node scripts/devnet-integration.mjs --help`
- `node scripts/devnet-integration-deep.mjs --help`