### PR TITLE
chore(release): cut sdk 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Deprecated
 - `VERIFICATION_COMPUTE_UNITS` in `sdk/src/constants.ts` — use `RECOMMENDED_CU_COMPLETE_TASK_PRIVATE` instead. Removal planned for v2.0.0. (#983)
 
+## [1.4.0] - 2026-04-12
+
+### Added
+- Marketplace V2 bid flows and expanded devnet validation tooling.
+- Task validation v2 client helpers and public docs for the validation surface.
+
+### Fixed
+- Refreshed Anchor error decoding and dispute/expiry account handling for current protocol flows.
+
 ## [1.3.1] - 2026-03-20
 
 ### Changed

--- a/docs/api-baseline/sdk.json
+++ b/docs/api-baseline/sdk.json
@@ -1,6 +1,6 @@
 {
   "package": "@tetsuo-ai/sdk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "generatedAt": "2026-03-21T13:55:39.039Z",
   "entryPoint": "src/index.ts",
   "exports": [

--- a/examples/private-task-demo/package.json
+++ b/examples/private-task-demo/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@tetsuo-ai/sdk": "1.3.1",
+    "@tetsuo-ai/sdk": "1.4.0",
     "@solana/web3.js": "^1.98.4"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetsuo-ai/sdk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetsuo-ai/sdk",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@coral-xyz/anchor": ">=0.32.1",
@@ -3341,21 +3341,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/sdk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "TypeScript SDK for AgenC - Privacy-preserving agent coordination on Solana",
   "packageManager": "npm@11.7.0",
   "main": "dist/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -48,7 +48,7 @@ export const SDK_PROTOCOL_VERSION = 1;
 export const SDK_MIN_PROTOCOL_VERSION = 1;
 
 /** Human-readable SDK package version. Keep in sync with package.json. */
-export const SDK_PACKAGE_VERSION = "1.3.1";
+export const SDK_PACKAGE_VERSION = "1.4.0";
 
 const FEATURE_REGISTRY: Record<number, Partial<FeatureFlags>> = {
   1: {


### PR DESCRIPTION
## Summary
- merge the public package release branch into `main`
- carry the sdk version bump and lockfile refresh
- keep the generated api baseline and release changelog entry
