### PR TITLE
Hide verifier and attestor internals from SDK root exports

### DIFF
--- a/docs/api-baseline/sdk.json
+++ b/docs/api-baseline/sdk.json
@@ -1278,10 +1278,6 @@
       "signature": "(payload: Risc0PayloadLike): void"
     },
     {
-      "name": "VERIFIER_PROGRAM_ID",
-      "kind": "const"
-    },
-    {
       "name": "VERSION",
       "kind": "const"
     },

--- a/examples/private-task-demo/index.ts
+++ b/examples/private-task-demo/index.ts
@@ -11,13 +11,13 @@ import {
   PROGRAM_ID as AGENC_PROGRAM_ID,
   TRUSTED_RISC0_SELECTOR,
   TRUSTED_RISC0_IMAGE_ID,
-  VERIFIER_PROGRAM_ID as TRUSTED_VERIFIER_PROGRAM_ID,
   computeHashes,
 } from '@tetsuo-ai/sdk';
 
 const HELIUS_API_KEY = process.env.HELIUS_API_KEY || 'YOUR_HELIUS_KEY';
 const HELIUS_RPC = `https://mainnet.helius-rpc.com/?api-key=${HELIUS_API_KEY}`;
 const TRUSTED_ROUTER_PROGRAM_ID = new PublicKey('E9ZiqfCdr6gGeB2UhBbkWnFP9vGnRYQwqnDsS1LM3NJZ');
+const TRUSTED_VERIFIER_PROGRAM_ID = new PublicKey('3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc');
 const TRUSTED_SELECTOR = Buffer.from(TRUSTED_RISC0_SELECTOR);
 const TRUSTED_IMAGE_ID = Buffer.from(TRUSTED_RISC0_IMAGE_ID);
 

--- a/src/__tests__/tasks.test.ts
+++ b/src/__tests__/tasks.test.ts
@@ -19,7 +19,6 @@ import {
   deriveClaimPda,
   deriveTaskValidationConfigPda,
   deriveTaskJobSpecPda,
-  deriveTaskAttestorConfigPda,
   setTaskJobSpec,
   claimTaskWithJobSpec,
   getTaskJobSpec,
@@ -282,20 +281,6 @@ describe("PDA derivation", () => {
 
       const [expected] = PublicKey.findProgramAddressSync(
         [SEEDS.TASK_JOB_SPEC, taskPda.toBuffer()],
-        PROGRAM_ID,
-      );
-      expect(result.equals(expected)).toBe(true);
-    });
-  });
-
-  describe("deriveTaskAttestorConfigPda", () => {
-    it('uses correct seeds: ["task_attestor", taskPda]', () => {
-      const taskPda = Keypair.generate().publicKey;
-
-      const result = deriveTaskAttestorConfigPda(taskPda);
-
-      const [expected] = PublicKey.findProgramAddressSync(
-        [SEEDS.TASK_ATTESTOR, taskPda.toBuffer()],
         PROGRAM_ID,
       );
       expect(result.equals(expected)).toBe(true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,11 +18,6 @@ export const PRIVACY_CASH_PROGRAM_ID = new PublicKey(
   "9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD",
 );
 
-/** AgenC verifier program ID — must match TRUSTED_RISC0_VERIFIER_PROGRAM_ID on-chain */
-export const VERIFIER_PROGRAM_ID = new PublicKey(
-  "3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc",
-);
-
 // ============================================================================
 // RPC Endpoints
 // ============================================================================
@@ -257,7 +252,6 @@ export const SEEDS = {
   CLAIM: Buffer.from("claim"),
   TASK_VALIDATION: Buffer.from("task_validation"),
   TASK_JOB_SPEC: Buffer.from("task_job_spec"),
-  TASK_ATTESTOR: Buffer.from("task_attestor"),
   TASK_SUBMISSION: Buffer.from("task_submission"),
   TASK_VALIDATION_VOTE: Buffer.from("task_validation_vote"),
   AUTHORITY_RATE_LIMIT: Buffer.from("authority_rate_limit"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ export {
   deriveClaimPda,
   deriveTaskValidationConfigPda,
   deriveTaskJobSpecPda,
-  deriveTaskAttestorConfigPda,
   deriveTaskSubmissionPda,
   deriveTaskValidationVotePda,
   deriveEscrowPda,
@@ -184,7 +183,6 @@ export {
 export {
   PROGRAM_ID,
   PRIVACY_CASH_PROGRAM_ID,
-  VERIFIER_PROGRAM_ID,
   DEVNET_RPC,
   MAINNET_RPC,
   // Size constants

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -70,6 +70,8 @@ import { imageIdsEqual, validateRisc0PayloadShape } from "./validation";
 
 export { TaskState };
 
+const TASK_ATTESTOR_SEED = Buffer.from("task_attestor");
+
 export enum TaskValidationMode {
   Auto = 0,
   CreatorReview = 1,
@@ -408,16 +410,12 @@ export function deriveTaskJobSpecPda(
   return pda;
 }
 
-/**
- * Derive task attestor config PDA from task.
- * Seeds: ["task_attestor", task_pda]
- */
-export function deriveTaskAttestorConfigPda(
+function deriveTaskAttestorConfigPda(
   taskPda: PublicKey,
   programId: PublicKey = PROGRAM_ID,
 ): PublicKey {
   const [pda] = PublicKey.findProgramAddressSync(
-    [SEEDS.TASK_ATTESTOR, taskPda.toBuffer()],
+    [TASK_ATTESTOR_SEED, taskPda.toBuffer()],
     programId,
   );
   return pda;


### PR DESCRIPTION
## Summary
- remove the public verifier program constant and task attestor seed from the SDK root surface
- stop exporting the task attestor PDA helper from the root package and keep the PDA seed private inside task internals
- update public API tests and the API baseline to reflect the trimmed SDK contract

## Validation
- npm run typecheck
- npm test
- npm run build
- npm run api:baseline:check