### PR TITLE
Fix protocolConfig accounts for launch-control SDK calls

### DIFF
--- a/src/__tests__/disputes.test.ts
+++ b/src/__tests__/disputes.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Keypair, PublicKey } from "@solana/web3.js";
-import { deriveDisputePda, deriveVotePda } from "../disputes";
+import { cancelDispute, deriveDisputePda, deriveVotePda } from "../disputes";
 import { PROGRAM_ID, SEEDS } from "../constants";
+import { deriveProtocolPda } from "../protocol";
 
 describe("disputes PDA helpers", () => {
   it('deriveDisputePda uses ["dispute", disputeId] seeds', () => {
@@ -27,5 +28,45 @@ describe("disputes PDA helpers", () => {
     );
 
     expect(pda.equals(expected)).toBe(true);
+  });
+
+  it("cancelDispute passes protocolConfig for launch-control gates", async () => {
+    const authority = Keypair.generate();
+    const disputePda = Keypair.generate().publicKey;
+    const taskPda = Keypair.generate().publicKey;
+    const rpc = vi.fn().mockResolvedValue("cancel-dispute-tx");
+    const signers = vi.fn().mockReturnValue({ rpc });
+    const remainingAccounts = vi.fn().mockReturnValue({ rpc });
+    const accountsPartial = vi.fn().mockReturnValue({ signers, remainingAccounts });
+    const cancelDisputeMethod = vi.fn().mockReturnValue({ accountsPartial });
+    const program = {
+      programId: PROGRAM_ID,
+      methods: { cancelDispute: cancelDisputeMethod },
+    } as any;
+    const connection = {
+      confirmTransaction: vi.fn().mockResolvedValue({}),
+    } as any;
+
+    const result = await cancelDispute(
+      connection,
+      program,
+      authority,
+      disputePda,
+      taskPda,
+    );
+
+    expect(result.txSignature).toBe("cancel-dispute-tx");
+    expect(accountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocolConfig: deriveProtocolPda(PROGRAM_ID),
+        dispute: disputePda,
+        task: taskPda,
+        authority: authority.publicKey,
+      }),
+    );
+    expect(connection.confirmTransaction).toHaveBeenCalledWith(
+      "cancel-dispute-tx",
+      "confirmed",
+    );
   });
 });

--- a/src/__tests__/tasks.test.ts
+++ b/src/__tests__/tasks.test.ts
@@ -29,6 +29,7 @@ import {
   calculateEscrowFee,
 } from "../tasks";
 import { PROGRAM_ID, SEEDS } from "../constants";
+import { deriveProtocolPda } from "../protocol";
 
 describe("TaskState enum", () => {
   describe("enum values match on-chain TaskStatus", () => {
@@ -369,6 +370,7 @@ describe("task job spec helpers", () => {
     });
 
     const expectedPda = deriveTaskJobSpecPda(taskPda);
+    const expectedProtocolPda = deriveProtocolPda(PROGRAM_ID);
     expect(result.txSignature).toBe("set-job-spec-tx");
     expect(result.taskJobSpecPda.equals(expectedPda)).toBe(true);
     expect(setTaskJobSpecMethod).toHaveBeenCalledWith(
@@ -377,6 +379,7 @@ describe("task job spec helpers", () => {
     );
     expect(accountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({
+        protocolConfig: expectedProtocolPda,
         task: taskPda,
         taskJobSpec: expectedPda,
         creator: creator.publicKey,

--- a/src/disputes.ts
+++ b/src/disputes.ts
@@ -565,9 +565,11 @@ export async function cancelDispute(
   taskPda: PublicKey,
   defendantAgentPda?: PublicKey,
 ): Promise<{ txSignature: string }> {
+  const protocolPda = deriveProtocolPda(program.programId);
   const builder = program.methods
     .cancelDispute()
     .accountsPartial({
+      protocolConfig: protocolPda,
       dispute: disputePda,
       task: taskPda,
       authority: authority.publicKey,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1027,10 +1027,12 @@ export async function setTaskJobSpec(
   }
 
   const taskJobSpecPda = deriveTaskJobSpecPda(taskPda, program.programId);
+  const protocolPda = deriveProtocolPda(program.programId);
   const tx = await submitTaskCreationTransaction(connection, "setTaskJobSpec", () =>
     program.methods
       .setTaskJobSpec(Array.from(jobSpecHash), jobSpecUri)
       .accountsPartial({
+        protocolConfig: protocolPda,
         task: taskPda,
         taskJobSpec: taskJobSpecPda,
         creator: creator.publicKey,


### PR DESCRIPTION
## Summary
- pass the protocol config PDA into setTaskJobSpec so SDK callers match the protocol #35 launch-control account layout
- pass the protocol config PDA into cancelDispute for the same launch-control gate
- add regression coverage for both SDK helpers

## Validation
- npm test -- --run src/__tests__/tasks.test.ts src/__tests__/disputes.test.ts
- npm run typecheck
- npm test
- npm run build