### PR TITLE
feat(sdk): expose daemon client transcript surface

### DIFF
--- a/examples/daemon-coattach/README.md
+++ b/examples/daemon-coattach/README.md
@@ -15,7 +15,9 @@ The example:
 The standalone `npm run start` path uses the current JSON-line daemon protocol
 fallback for the TUI side. In the runtime contract test, the same flow is wired
 to the actual TUI daemon bridge so the SDK and TUI attachments share daemon
-session state and event fan-out.
+session state and event fan-out. That runtime contract is the authoritative
+bridge integration until the SDK exposes the daemon initialize and subscription
+transport surfaces directly.
 
 The temporary JSON-line transport is intentionally local to the example. Replace
 it with the SDK daemon transport once the initialize/version handshake and

--- a/examples/daemon-coattach/README.md
+++ b/examples/daemon-coattach/README.md
@@ -1,0 +1,24 @@
+# Daemon Co-Attach
+
+Minimal AgenC SDK example for sharing one daemon session between an SDK client
+and the TUI daemon bridge.
+
+The example:
+
+- creates one daemon session through the SDK wrapper
+- attaches an SDK client ID and a TUI client ID to that same session
+- sends one SDK message and one TUI-style streamed message
+- lists sessions and verifies both attachments remain visible on the same
+  session
+
+## Run It
+
+From this directory:
+
+```bash
+npm install --no-fund
+npm run start
+```
+
+Set `AGENC_DAEMON_SOCKET` to override the socket path. If unset, the example
+uses `$HOME/.agenc/daemon.sock`.

--- a/examples/daemon-coattach/README.md
+++ b/examples/daemon-coattach/README.md
@@ -6,10 +6,20 @@ and the TUI daemon bridge.
 The example:
 
 - creates one daemon session through the SDK wrapper
-- attaches an SDK client ID and a TUI client ID to that same session
+- attaches an SDK client ID to that session
+- accepts an injectable TUI attachment surface for the real TUI daemon bridge
 - sends one SDK message and one TUI-style streamed message
 - lists sessions and verifies both attachments remain visible on the same
   session
+
+The standalone `npm run start` path uses the current JSON-line daemon protocol
+fallback for the TUI side. In the runtime contract test, the same flow is wired
+to the actual TUI daemon bridge so the SDK and TUI attachments share daemon
+session state and event fan-out.
+
+The temporary JSON-line transport is intentionally local to the example. Replace
+it with the SDK daemon transport once the initialize/version handshake and
+subscription transport are public SDK surfaces.
 
 ## Run It
 

--- a/examples/daemon-coattach/index.test.ts
+++ b/examples/daemon-coattach/index.test.ts
@@ -34,14 +34,7 @@ describe("daemon co-attach example", () => {
           acceptedAt: "2026-05-01T00:00:01.000Z",
         };
       }),
-      streamMessage: vi.fn().mockImplementation(async (params) => {
-        calls.push(`tui:${params.sessionId}`);
-        return {
-          messageId: "message_tui",
-          streamId: params.streamId,
-          acceptedAt: "2026-05-01T00:00:02.000Z",
-        };
-      }),
+      streamMessage: vi.fn(),
       listSessions: vi.fn().mockImplementation(async () => {
         calls.push("listSessions");
         return {
@@ -60,8 +53,27 @@ describe("daemon co-attach example", () => {
         };
       }),
     };
+    const attachTui = vi.fn().mockImplementation(async (options) => {
+      calls.push(`attachTui:${options.clientId}`);
+      return {
+        attachmentId: "tui-test_attachment",
+        submit: async (message: string) => {
+          calls.push(`tui:${options.sessionId}`);
+          expect(message).toBe("hello from tui");
+          expect(options.clientId).toBe("tui-test");
+          expect(options.sessionId).toBe("session_1");
+          expect(options.client).toBe(client);
+          return {
+            messageId: "message_tui",
+            streamId: "tui-test:hello-world",
+            acceptedAt: "2026-05-01T00:00:02.000Z",
+          };
+        },
+      };
+    });
 
     const result = await runDaemonCoAttach({
+      attachTui,
       client,
       cwd: "/workspace",
       sdkClientId: "sdk-test",
@@ -73,7 +85,7 @@ describe("daemon co-attach example", () => {
     expect(calls).toEqual([
       "createSession",
       "attach:sdk-test",
-      "attach:tui-test",
+      "attachTui:tui-test",
       "sdk:session_1",
       "tui:session_1",
       "listSessions",
@@ -83,15 +95,86 @@ describe("daemon co-attach example", () => {
       initialPrompt: "hello from sdk",
       metadata: { source: "sdk-tui-coattach" },
     });
+    expect(attachTui).toHaveBeenCalledWith({
+      client,
+      sessionId: "session_1",
+      clientId: "tui-test",
+    });
+    expect(result.tuiMessage).toEqual({
+      messageId: "message_tui",
+      streamId: "tui-test:hello-world",
+      acceptedAt: "2026-05-01T00:00:02.000Z",
+    });
+    expect(result.visibleSession.activeAttachmentIds).toEqual([
+      "sdk-test_attachment",
+      "tui-test_attachment",
+    ]);
+  });
+
+  it("provides a protocol fallback for the TUI side", async () => {
+    const calls: string[] = [];
+    const client = {
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: "session_1",
+        agentId: "agent_default",
+        status: "idle",
+        createdAt: "2026-05-01T00:00:00.000Z",
+      }),
+      attachSession: vi.fn().mockImplementation(async (params) => {
+        calls.push(`attach:${params.clientId}`);
+        return {
+          sessionId: "session_1",
+          attachmentId: `${params.clientId}_attachment`,
+          attachedAt: "2026-05-01T00:00:00.100Z",
+          clientId: params.clientId,
+          activeAttachmentIds:
+            params.clientId === "tui-test"
+              ? ["sdk-test_attachment", "tui-test_attachment"]
+              : ["sdk-test_attachment"],
+        };
+      }),
+      sendMessage: vi.fn().mockResolvedValue({
+        messageId: "message_sdk",
+        acceptedAt: "2026-05-01T00:00:01.000Z",
+      }),
+      streamMessage: vi.fn().mockResolvedValue({
+        messageId: "message_tui",
+        streamId: "tui-test:hello-world",
+        acceptedAt: "2026-05-01T00:00:02.000Z",
+      }),
+      listSessions: vi.fn().mockImplementation(async () => {
+        return {
+          sessions: [
+            {
+              sessionId: "session_1",
+              agentId: "agent_default",
+              status: "idle",
+              createdAt: "2026-05-01T00:00:00.000Z",
+              activeAttachmentIds: [
+                "sdk-test_attachment",
+                "tui-test_attachment",
+              ],
+            },
+          ],
+        };
+      }),
+    };
+
+    await runDaemonCoAttach({
+      client,
+      cwd: "/workspace",
+      sdkClientId: "sdk-test",
+      sdkPrompt: "hello from sdk",
+      tuiClientId: "tui-test",
+      tuiPrompt: "hello from tui",
+    });
+
     expect(client.streamMessage).toHaveBeenCalledWith({
       sessionId: "session_1",
       content: "hello from tui",
       streamId: "tui-test:hello-world",
       metadata: { source: "tui-test" },
     });
-    expect(result.visibleSession.activeAttachmentIds).toEqual([
-      "sdk-test_attachment",
-      "tui-test_attachment",
-    ]);
+    expect(calls).toEqual(["attach:sdk-test", "attach:tui-test"]);
   });
 });

--- a/examples/daemon-coattach/index.test.ts
+++ b/examples/daemon-coattach/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDaemonCoAttach } from "./index.js";
+
+describe("daemon co-attach example", () => {
+  it("drives one session through SDK and TUI attachments", async () => {
+    const calls: string[] = [];
+    const client = {
+      createSession: vi.fn().mockImplementation(async () => {
+        calls.push("createSession");
+        return {
+          sessionId: "session_1",
+          agentId: "agent_default",
+          status: "idle",
+          createdAt: "2026-05-01T00:00:00.000Z",
+        };
+      }),
+      attachSession: vi.fn().mockImplementation(async (params) => {
+        calls.push(`attach:${params.clientId}`);
+        return {
+          sessionId: "session_1",
+          attachmentId: `${params.clientId}_attachment`,
+          attachedAt: "2026-05-01T00:00:00.100Z",
+          clientId: params.clientId,
+          activeAttachmentIds:
+            params.clientId === "tui-test"
+              ? ["sdk-test_attachment", "tui-test_attachment"]
+              : ["sdk-test_attachment"],
+        };
+      }),
+      sendMessage: vi.fn().mockImplementation(async (params) => {
+        calls.push(`sdk:${params.sessionId}`);
+        return {
+          messageId: "message_sdk",
+          acceptedAt: "2026-05-01T00:00:01.000Z",
+        };
+      }),
+      streamMessage: vi.fn().mockImplementation(async (params) => {
+        calls.push(`tui:${params.sessionId}`);
+        return {
+          messageId: "message_tui",
+          streamId: params.streamId,
+          acceptedAt: "2026-05-01T00:00:02.000Z",
+        };
+      }),
+      listSessions: vi.fn().mockImplementation(async () => {
+        calls.push("listSessions");
+        return {
+          sessions: [
+            {
+              sessionId: "session_1",
+              agentId: "agent_default",
+              status: "idle",
+              createdAt: "2026-05-01T00:00:00.000Z",
+              activeAttachmentIds: [
+                "sdk-test_attachment",
+                "tui-test_attachment",
+              ],
+            },
+          ],
+        };
+      }),
+    };
+
+    const result = await runDaemonCoAttach({
+      client,
+      cwd: "/workspace",
+      sdkClientId: "sdk-test",
+      sdkPrompt: "hello from sdk",
+      tuiClientId: "tui-test",
+      tuiPrompt: "hello from tui",
+    });
+
+    expect(calls).toEqual([
+      "createSession",
+      "attach:sdk-test",
+      "attach:tui-test",
+      "sdk:session_1",
+      "tui:session_1",
+      "listSessions",
+    ]);
+    expect(client.createSession).toHaveBeenCalledWith({
+      cwd: "/workspace",
+      initialPrompt: "hello from sdk",
+      metadata: { source: "sdk-tui-coattach" },
+    });
+    expect(client.streamMessage).toHaveBeenCalledWith({
+      sessionId: "session_1",
+      content: "hello from tui",
+      streamId: "tui-test:hello-world",
+      metadata: { source: "tui-test" },
+    });
+    expect(result.visibleSession.activeAttachmentIds).toEqual([
+      "sdk-test_attachment",
+      "tui-test_attachment",
+    ]);
+  });
+});

--- a/examples/daemon-coattach/index.ts
+++ b/examples/daemon-coattach/index.ts
@@ -33,6 +33,9 @@ interface UnixSocketTransportOptions {
 }
 
 export interface DaemonCoAttachOptions {
+  readonly attachTui?: (
+    options: DaemonTuiAttachOptions,
+  ) => Promise<DaemonTuiAttachment>;
   readonly client?: Pick<
     AgenCDaemonClient,
     | "attachSession"
@@ -50,10 +53,21 @@ export interface DaemonCoAttachOptions {
   readonly tuiPrompt?: string;
 }
 
+export interface DaemonTuiAttachOptions {
+  readonly client: Pick<AgenCDaemonClient, "attachSession" | "streamMessage">;
+  readonly clientId: string;
+  readonly sessionId: string;
+}
+
+export interface DaemonTuiAttachment {
+  readonly attachmentId: string;
+  submit(message: string): Promise<MessageStreamResult>;
+}
+
 export interface DaemonCoAttachResult {
   readonly session: SessionCreateResult;
   readonly sdkAttachment: SessionAttachResult;
-  readonly tuiAttachment: SessionAttachResult;
+  readonly tuiAttachment: DaemonTuiAttachment;
   readonly sdkMessage: MessageSendResult;
   readonly tuiMessage: MessageStreamResult;
   readonly visibleSession: SessionSummary;
@@ -145,7 +159,9 @@ export async function runDaemonCoAttach(
     sessionId: session.sessionId,
     clientId: sdkClientId,
   });
-  const tuiAttachment = await client.attachSession({
+  const attachTui = options.attachTui ?? attachProtocolTuiSide;
+  const tuiAttachment = await attachTui({
+    client,
     sessionId: session.sessionId,
     clientId: tuiClientId,
   });
@@ -154,12 +170,7 @@ export async function runDaemonCoAttach(
     content: sdkPrompt,
     metadata: { source: sdkClientId },
   });
-  const tuiMessage = await client.streamMessage({
-    sessionId: session.sessionId,
-    content: tuiPrompt,
-    streamId: `${tuiClientId}:hello-world`,
-    metadata: { source: tuiClientId },
-  });
+  const tuiMessage = await tuiAttachment.submit(tuiPrompt);
   const listed = await client.listSessions({ agentId: session.agentId });
   const visibleSession = listed.sessions.find(
     (candidate) => candidate.sessionId === session.sessionId,
@@ -178,6 +189,25 @@ export async function runDaemonCoAttach(
     sdkMessage,
     tuiMessage,
     visibleSession,
+  };
+}
+
+async function attachProtocolTuiSide(
+  options: DaemonTuiAttachOptions,
+): Promise<DaemonTuiAttachment> {
+  const attachment = await options.client.attachSession({
+    sessionId: options.sessionId,
+    clientId: options.clientId,
+  });
+  return {
+    attachmentId: attachment.attachmentId,
+    submit: (message) =>
+      options.client.streamMessage({
+        sessionId: options.sessionId,
+        content: message,
+        streamId: `${options.clientId}:hello-world`,
+        metadata: { source: options.clientId },
+      }),
   };
 }
 

--- a/examples/daemon-coattach/index.ts
+++ b/examples/daemon-coattach/index.ts
@@ -1,0 +1,233 @@
+/**
+ * AgenC daemon co-attach example:
+ * one SDK client and one TUI client ID drive the same daemon session.
+ */
+
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createAgenCDaemonClient,
+  type AgenCDaemonClient,
+  type AgenCDaemonMethod,
+  type AgenCDaemonRequest,
+  type AgenCDaemonResponse,
+  type AgenCDaemonTransport,
+  type MessageSendResult,
+  type MessageStreamResult,
+  type SessionAttachResult,
+  type SessionCreateResult,
+  type SessionSummary,
+} from "@tetsuo-ai/sdk";
+
+const DEFAULT_SDK_PROMPT = "Hello from the SDK side.";
+const DEFAULT_TUI_PROMPT = "Hello from the TUI side.";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_SDK_CLIENT_ID = "sdk-example";
+const DEFAULT_TUI_CLIENT_ID = "tui-example";
+
+interface UnixSocketTransportOptions {
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface DaemonCoAttachOptions {
+  readonly client?: Pick<
+    AgenCDaemonClient,
+    | "attachSession"
+    | "createSession"
+    | "listSessions"
+    | "sendMessage"
+    | "streamMessage"
+  >;
+  readonly cwd?: string;
+  readonly sdkClientId?: string;
+  readonly sdkPrompt?: string;
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+  readonly tuiClientId?: string;
+  readonly tuiPrompt?: string;
+}
+
+export interface DaemonCoAttachResult {
+  readonly session: SessionCreateResult;
+  readonly sdkAttachment: SessionAttachResult;
+  readonly tuiAttachment: SessionAttachResult;
+  readonly sdkMessage: MessageSendResult;
+  readonly tuiMessage: MessageStreamResult;
+  readonly visibleSession: SessionSummary;
+}
+
+class UnixSocketJsonLineTransport implements AgenCDaemonTransport {
+  readonly #socketPath: string;
+  readonly #timeoutMs: number;
+
+  constructor(options: UnixSocketTransportOptions = {}) {
+    this.#socketPath = options.socketPath ?? defaultAgenCDaemonSocketPath();
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  request<Method extends AgenCDaemonMethod>(
+    request: AgenCDaemonRequest<Method>,
+  ): Promise<AgenCDaemonResponse<Method>> {
+    return new Promise((resolve, reject) => {
+      const socket = createConnection(this.#socketPath);
+      let buffer = "";
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout>;
+
+      const finish = (
+        error: Error | null,
+        response?: AgenCDaemonResponse<Method>,
+      ) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        socket.destroy();
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(response!);
+      };
+
+      timeout = setTimeout(() => {
+        finish(new Error(`Timed out waiting for ${request.method}`));
+      }, this.#timeoutMs);
+
+      socket.setEncoding("utf8");
+      socket.once("connect", () => {
+        socket.write(`${JSON.stringify(request)}\n`);
+      });
+      socket.on("data", (chunk) => {
+        buffer += chunk;
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) return;
+
+        const line = buffer.slice(0, newline);
+        try {
+          finish(null, JSON.parse(line) as AgenCDaemonResponse<Method>);
+        } catch (error) {
+          finish(asError(error));
+        }
+      });
+      socket.once("error", finish);
+      socket.once("close", () => {
+        finish(new Error(`Daemon connection closed before ${request.method}`));
+      });
+    });
+  }
+}
+
+export async function runDaemonCoAttach(
+  options: DaemonCoAttachOptions = {},
+): Promise<DaemonCoAttachResult> {
+  const sdkClientId = options.sdkClientId ?? DEFAULT_SDK_CLIENT_ID;
+  const tuiClientId = options.tuiClientId ?? DEFAULT_TUI_CLIENT_ID;
+  const sdkPrompt = options.sdkPrompt?.trim() || DEFAULT_SDK_PROMPT;
+  const tuiPrompt = options.tuiPrompt?.trim() || DEFAULT_TUI_PROMPT;
+  const client =
+    options.client ??
+    createAgenCDaemonClient({
+      transport: new UnixSocketJsonLineTransport({
+        socketPath: options.socketPath,
+        timeoutMs: options.timeoutMs,
+      }),
+    });
+
+  const session = await client.createSession({
+    cwd: options.cwd ?? process.cwd(),
+    initialPrompt: sdkPrompt,
+    metadata: { source: "sdk-tui-coattach" },
+  });
+  const sdkAttachment = await client.attachSession({
+    sessionId: session.sessionId,
+    clientId: sdkClientId,
+  });
+  const tuiAttachment = await client.attachSession({
+    sessionId: session.sessionId,
+    clientId: tuiClientId,
+  });
+  const sdkMessage = await client.sendMessage({
+    sessionId: session.sessionId,
+    content: sdkPrompt,
+    metadata: { source: sdkClientId },
+  });
+  const tuiMessage = await client.streamMessage({
+    sessionId: session.sessionId,
+    content: tuiPrompt,
+    streamId: `${tuiClientId}:hello-world`,
+    metadata: { source: tuiClientId },
+  });
+  const listed = await client.listSessions({ agentId: session.agentId });
+  const visibleSession = listed.sessions.find(
+    (candidate) => candidate.sessionId === session.sessionId,
+  );
+
+  if (visibleSession === undefined) {
+    throw new Error(`Session ${session.sessionId} was not visible to listSessions`);
+  }
+  assertAttachmentVisible(visibleSession, sdkAttachment.attachmentId);
+  assertAttachmentVisible(visibleSession, tuiAttachment.attachmentId);
+
+  return {
+    session,
+    sdkAttachment,
+    tuiAttachment,
+    sdkMessage,
+    tuiMessage,
+    visibleSession,
+  };
+}
+
+async function main(): Promise<void> {
+  const { session, sdkAttachment, tuiAttachment, sdkMessage, tuiMessage } =
+    await runDaemonCoAttach({
+      socketPath: process.env.AGENC_DAEMON_SOCKET,
+    });
+
+  console.log(
+    JSON.stringify(
+      {
+        sessionId: session.sessionId,
+        sdkAttachmentId: sdkAttachment.attachmentId,
+        tuiAttachmentId: tuiAttachment.attachmentId,
+        sdkMessageId: sdkMessage.messageId,
+        tuiStreamId: tuiMessage.streamId,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function assertAttachmentVisible(
+  session: SessionSummary,
+  attachmentId: string,
+): void {
+  if (!session.activeAttachmentIds?.includes(attachmentId)) {
+    throw new Error(
+      `Session ${session.sessionId} did not expose attachment ${attachmentId}`,
+    );
+  }
+}
+
+function isMainModule(): boolean {
+  return process.argv[1] === fileURLToPath(import.meta.url);
+}
+
+function defaultAgenCDaemonSocketPath(): string {
+  return join(homedir(), ".agenc", "daemon.sock");
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+if (isMainModule()) {
+  main().catch((error: unknown) => {
+    console.error(asError(error).message);
+    process.exitCode = 1;
+  });
+}

--- a/examples/daemon-coattach/package.json
+++ b/examples/daemon-coattach/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tetsuo-ai/daemon-coattach",
+  "version": "1.0.0",
+  "private": true,
+  "description": "AgenC SDK and TUI co-attach example over one daemon session",
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "test": "vitest run index.test.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@tetsuo-ai/sdk": "file:../.."
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/examples/daemon-coattach/tsconfig.json
+++ b/examples/daemon-coattach/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "vitest"],
+    "baseUrl": ".",
+    "paths": {
+      "@tetsuo-ai/sdk": ["../../src/index.ts"]
+    }
+  },
+  "include": ["index.ts", "index.test.ts"]
+}

--- a/examples/daemon-hello-world/README.md
+++ b/examples/daemon-hello-world/README.md
@@ -1,0 +1,18 @@
+# Daemon Hello World
+
+Minimal AgenC SDK example for the daemon JSON-RPC wrapper.
+
+It opens the local AgenC daemon Unix socket, creates a session, sends one
+message, and waits for the `message.send` response.
+
+## Run It
+
+From this directory:
+
+```bash
+npm install --no-fund
+npm run start -- "Say hello from the SDK"
+```
+
+Set `AGENC_DAEMON_SOCKET` to override the socket path. If unset, the example
+uses `$HOME/.agenc/daemon.sock`.

--- a/examples/daemon-hello-world/index.test.ts
+++ b/examples/daemon-hello-world/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDaemonHelloWorld } from "./index.js";
+
+describe("daemon hello-world example", () => {
+  it("creates a session and sends one message through the SDK client", async () => {
+    const client = {
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: "session_1",
+        agentId: "agent_default",
+        status: "idle",
+        createdAt: "2026-05-01T00:00:00.000Z",
+      }),
+      sendMessage: vi.fn().mockResolvedValue({
+        messageId: "message_1",
+        acceptedAt: "2026-05-01T00:00:01.000Z",
+      }),
+    };
+
+    const result = await runDaemonHelloWorld({
+      client,
+      cwd: "/workspace",
+      prompt: "Hello from test",
+    });
+
+    expect(client.createSession).toHaveBeenCalledWith({
+      cwd: "/workspace",
+      initialPrompt: "Hello from test",
+      metadata: { source: "sdk-daemon-hello-world" },
+    });
+    expect(client.sendMessage).toHaveBeenCalledWith({
+      sessionId: "session_1",
+      content: "Hello from test",
+      metadata: { source: "sdk-daemon-hello-world" },
+    });
+    expect(result.response.messageId).toBe("message_1");
+  });
+});

--- a/examples/daemon-hello-world/index.ts
+++ b/examples/daemon-hello-world/index.ts
@@ -1,0 +1,128 @@
+/**
+ * Minimal AgenC daemon example:
+ * create a session, send one message, and await the JSON-RPC response.
+ */
+
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  createAgenCDaemonClient,
+  type AgenCDaemonMethod,
+  type AgenCDaemonRequest,
+  type AgenCDaemonResponse,
+  type AgenCDaemonTransport,
+} from "@tetsuo-ai/sdk";
+
+const DEFAULT_PROMPT = "Say hello from the AgenC SDK.";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface UnixSocketTransportOptions {
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+}
+
+class UnixSocketJsonLineTransport implements AgenCDaemonTransport {
+  readonly #socketPath: string;
+  readonly #timeoutMs: number;
+
+  constructor(options: UnixSocketTransportOptions = {}) {
+    this.#socketPath = options.socketPath ?? defaultAgenCDaemonSocketPath();
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  request<Method extends AgenCDaemonMethod>(
+    request: AgenCDaemonRequest<Method>,
+  ): Promise<AgenCDaemonResponse<Method>> {
+    return new Promise((resolve, reject) => {
+      const socket = createConnection(this.#socketPath);
+      let buffer = "";
+      let settled = false;
+
+      const timeout = setTimeout(() => {
+        finish(new Error(`Timed out waiting for ${request.method}`));
+      }, this.#timeoutMs);
+
+      const finish = (
+        error: Error | null,
+        response?: AgenCDaemonResponse<Method>,
+      ) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        socket.destroy();
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(response!);
+      };
+
+      socket.setEncoding("utf8");
+      socket.once("connect", () => {
+        socket.write(`${JSON.stringify(request)}\n`);
+      });
+      socket.on("data", (chunk) => {
+        buffer += chunk;
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) return;
+
+        const line = buffer.slice(0, newline);
+        try {
+          finish(null, JSON.parse(line) as AgenCDaemonResponse<Method>);
+        } catch (error) {
+          finish(asError(error));
+        }
+      });
+      socket.once("error", finish);
+      socket.once("close", () => {
+        finish(new Error(`Daemon connection closed before ${request.method}`));
+      });
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  const prompt = process.argv.slice(2).join(" ").trim() || DEFAULT_PROMPT;
+  const client = createAgenCDaemonClient({
+    transport: new UnixSocketJsonLineTransport({
+      socketPath: process.env.AGENC_DAEMON_SOCKET,
+    }),
+  });
+
+  const session = await client.createSession({
+    cwd: process.cwd(),
+    initialPrompt: prompt,
+    metadata: { source: "sdk-daemon-hello-world" },
+  });
+  const response = await client.sendMessage({
+    sessionId: session.sessionId,
+    content: prompt,
+    metadata: { source: "sdk-daemon-hello-world" },
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        sessionId: session.sessionId,
+        messageId: response.messageId,
+        acceptedAt: response.acceptedAt,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function defaultAgenCDaemonSocketPath(): string {
+  return join(homedir(), ".agenc", "daemon.sock");
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+main().catch((error: unknown) => {
+  console.error(asError(error).message);
+  process.exitCode = 1;
+});

--- a/examples/daemon-hello-world/index.ts
+++ b/examples/daemon-hello-world/index.ts
@@ -6,12 +6,16 @@
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   createAgenCDaemonClient,
+  type AgenCDaemonClient,
   type AgenCDaemonMethod,
   type AgenCDaemonRequest,
   type AgenCDaemonResponse,
   type AgenCDaemonTransport,
+  type MessageSendResult,
+  type SessionCreateResult,
 } from "@tetsuo-ai/sdk";
 
 const DEFAULT_PROMPT = "Say hello from the AgenC SDK.";
@@ -20,6 +24,19 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 interface UnixSocketTransportOptions {
   readonly socketPath?: string;
   readonly timeoutMs?: number;
+}
+
+export interface DaemonHelloWorldOptions {
+  readonly client?: Pick<AgenCDaemonClient, "createSession" | "sendMessage">;
+  readonly cwd?: string;
+  readonly prompt?: string;
+  readonly socketPath?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface DaemonHelloWorldResult {
+  readonly session: SessionCreateResult;
+  readonly response: MessageSendResult;
 }
 
 class UnixSocketJsonLineTransport implements AgenCDaemonTransport {
@@ -82,16 +99,21 @@ class UnixSocketJsonLineTransport implements AgenCDaemonTransport {
   }
 }
 
-async function main(): Promise<void> {
-  const prompt = process.argv.slice(2).join(" ").trim() || DEFAULT_PROMPT;
-  const client = createAgenCDaemonClient({
-    transport: new UnixSocketJsonLineTransport({
-      socketPath: process.env.AGENC_DAEMON_SOCKET,
-    }),
-  });
+export async function runDaemonHelloWorld(
+  options: DaemonHelloWorldOptions = {},
+): Promise<DaemonHelloWorldResult> {
+  const prompt = options.prompt?.trim() || DEFAULT_PROMPT;
+  const client =
+    options.client ??
+    createAgenCDaemonClient({
+      transport: new UnixSocketJsonLineTransport({
+        socketPath: options.socketPath,
+        timeoutMs: options.timeoutMs,
+      }),
+    });
 
   const session = await client.createSession({
-    cwd: process.cwd(),
+    cwd: options.cwd ?? process.cwd(),
     initialPrompt: prompt,
     metadata: { source: "sdk-daemon-hello-world" },
   });
@@ -99,6 +121,16 @@ async function main(): Promise<void> {
     sessionId: session.sessionId,
     content: prompt,
     metadata: { source: "sdk-daemon-hello-world" },
+  });
+
+  return { session, response };
+}
+
+async function main(): Promise<void> {
+  const prompt = process.argv.slice(2).join(" ").trim() || DEFAULT_PROMPT;
+  const { session, response } = await runDaemonHelloWorld({
+    prompt,
+    socketPath: process.env.AGENC_DAEMON_SOCKET,
   });
 
   console.log(
@@ -114,6 +146,10 @@ async function main(): Promise<void> {
   );
 }
 
+function isMainModule(): boolean {
+  return process.argv[1] === fileURLToPath(import.meta.url);
+}
+
 function defaultAgenCDaemonSocketPath(): string {
   return join(homedir(), ".agenc", "daemon.sock");
 }
@@ -122,7 +158,9 @@ function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-main().catch((error: unknown) => {
-  console.error(asError(error).message);
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch((error: unknown) => {
+    console.error(asError(error).message);
+    process.exitCode = 1;
+  });
+}

--- a/examples/daemon-hello-world/package.json
+++ b/examples/daemon-hello-world/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tetsuo-ai/daemon-hello-world",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal AgenC daemon session example using the SDK client wrapper",
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@tetsuo-ai/sdk": "file:../.."
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/examples/daemon-hello-world/package.json
+++ b/examples/daemon-hello-world/package.json
@@ -5,12 +5,16 @@
   "description": "Minimal AgenC daemon session example using the SDK client wrapper",
   "type": "module",
   "scripts": {
-    "start": "tsx index.ts"
+    "start": "tsx index.ts",
+    "test": "vitest run index.test.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@tetsuo-ai/sdk": "file:../.."
   },
   "devDependencies": {
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/examples/daemon-hello-world/tsconfig.json
+++ b/examples/daemon-hello-world/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "vitest"],
+    "baseUrl": ".",
+    "paths": {
+      "@tetsuo-ai/sdk": ["../../src/index.ts"]
+    }
+  },
+  "include": ["index.ts", "index.test.ts"]
+}

--- a/src/__tests__/daemon.test.ts
+++ b/src/__tests__/daemon.test.ts
@@ -5,6 +5,7 @@ import {
   AgenCDaemonMalformedResponseError,
   AgenCDaemonRpcError,
   createAgenCDaemonClient,
+  type AgenCDaemonNotification,
   type AgenCDaemonRequest,
   type AgenCDaemonResponse,
   type AgenCDaemonTransport,
@@ -72,6 +73,86 @@ describe("AgenCDaemonClient", () => {
       method: "agent.list",
       params: {},
     });
+  });
+
+  it("frames agent log and elicitation response requests", async () => {
+    const transport = createTransport((request) => {
+      if (request.method === "agent.logs") {
+        return {
+          jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+          id: request.id,
+          result: {
+            agentId: "agent_1",
+            transcript: "hello",
+            sessions: [],
+          },
+        };
+      }
+      return {
+        jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+        id: request.id,
+        result: {
+          requestId: "elicitation_1",
+          resolved: true,
+        },
+      };
+    });
+    const client = new AgenCDaemonClient({
+      transport,
+      createRequestId: vi
+        .fn()
+        .mockReturnValueOnce("logs_1")
+        .mockReturnValueOnce("elicitation_1"),
+    });
+
+    await expect(client.getAgentLogs({ agentId: "agent_1" })).resolves.toEqual({
+      agentId: "agent_1",
+      transcript: "hello",
+      sessions: [],
+    });
+    await expect(
+      client.respondToElicitation({
+        sessionId: "session_1",
+        requestId: "elicitation_1",
+        kind: "request_user_input",
+        response: { answer: "yes" },
+      }),
+    ).resolves.toEqual({
+      requestId: "elicitation_1",
+      resolved: true,
+    });
+
+    expect(transport.request).toHaveBeenNthCalledWith(1, {
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: "logs_1",
+      method: "agent.logs",
+      params: { agentId: "agent_1" },
+    });
+    expect(transport.request).toHaveBeenNthCalledWith(2, {
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: "elicitation_1",
+      method: "elicitation.respond",
+      params: {
+        sessionId: "session_1",
+        requestId: "elicitation_1",
+        kind: "request_user_input",
+        response: { answer: "yes" },
+      },
+    });
+  });
+
+  it("types daemon session event notifications", () => {
+    const notification = {
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      method: "event.message_chunk",
+      params: {
+        sessionId: "session_1",
+        eventId: "event_1",
+        delta: "hello",
+      },
+    } satisfies AgenCDaemonNotification<"event.message_chunk">;
+
+    expect(notification.method).toBe("event.message_chunk");
   });
 
   it("omits params for optional health/auth methods", async () => {

--- a/src/__tests__/daemon.test.ts
+++ b/src/__tests__/daemon.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENC_DAEMON_JSON_RPC_VERSION,
+  AgenCDaemonClient,
+  AgenCDaemonMalformedResponseError,
+  AgenCDaemonRpcError,
+  createAgenCDaemonClient,
+  type AgenCDaemonRequest,
+  type AgenCDaemonResponse,
+  type AgenCDaemonTransport,
+} from "../daemon";
+
+function createTransport(
+  handler: (
+    request: AgenCDaemonRequest,
+  ) => Promise<AgenCDaemonResponse> | AgenCDaemonResponse,
+): AgenCDaemonTransport & {
+  readonly request: ReturnType<typeof vi.fn>;
+} {
+  return {
+    request: vi.fn((request: AgenCDaemonRequest) => handler(request)),
+  };
+}
+
+describe("AgenCDaemonClient", () => {
+  it("frames typed agent.create requests without SDK-side agent logic", async () => {
+    const transport = createTransport((request) => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: request.id,
+      result: {
+        agentId: "agent_1",
+        status: "idle",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        cwd: "/workspace",
+      },
+    }));
+    const client = new AgenCDaemonClient({
+      transport,
+      createRequestId: () => "req_1",
+    });
+
+    const result = await client.createAgent({
+      cwd: "/workspace",
+      model: "grok-4",
+    });
+
+    expect(transport.request).toHaveBeenCalledWith({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: "req_1",
+      method: "agent.create",
+      params: {
+        cwd: "/workspace",
+        model: "grok-4",
+      },
+    });
+    expect(result.agentId).toBe("agent_1");
+  });
+
+  it("uses empty objects for required list-style params", async () => {
+    const transport = createTransport((request) => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: request.id,
+      result: { agents: [] },
+    }));
+    const client = createAgenCDaemonClient({ transport });
+
+    await expect(client.listAgents()).resolves.toEqual({ agents: [] });
+
+    expect(transport.request).toHaveBeenCalledWith({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: 1,
+      method: "agent.list",
+      params: {},
+    });
+  });
+
+  it("omits params for optional health/auth methods", async () => {
+    const transport = createTransport((request) => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: request.id,
+      result: {
+        ok: true,
+        now: "2026-05-01T00:00:00.000Z",
+      },
+    }));
+    const client = new AgenCDaemonClient({ transport });
+
+    await expect(client.ping()).resolves.toMatchObject({ ok: true });
+
+    expect(transport.request).toHaveBeenCalledWith({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: 1,
+      method: "health.ping",
+    });
+  });
+
+  it("throws structured JSON-RPC errors", async () => {
+    const transport = createTransport((request) => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: request.id,
+      error: {
+        code: -32601,
+        message: "Unknown method",
+      },
+    }));
+    const client = new AgenCDaemonClient({
+      transport,
+      createRequestId: () => "auth_1",
+    });
+
+    await expect(client.whoami()).rejects.toMatchObject({
+      name: "AgenCDaemonRpcError",
+      code: -32601,
+      method: "auth.whoami",
+      requestId: "auth_1",
+    } satisfies Partial<AgenCDaemonRpcError>);
+  });
+
+  it("rejects mismatched response ids", async () => {
+    const transport = createTransport(() => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: "other",
+      result: {
+        ready: true,
+        uptimeMs: 10,
+        now: "2026-05-01T00:00:00.000Z",
+      },
+    }));
+    const client = new AgenCDaemonClient({
+      transport,
+      createRequestId: () => "ready_1",
+    });
+
+    await expect(client.ready()).rejects.toBeInstanceOf(
+      AgenCDaemonMalformedResponseError,
+    );
+    await expect(client.ready()).rejects.toThrow("response id mismatch");
+  });
+
+  it("rejects responses without result or error", async () => {
+    const transport = createTransport((request) => ({
+      jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION,
+      id: request.id,
+    } as AgenCDaemonResponse));
+    const client = new AgenCDaemonClient({ transport });
+
+    await expect(client.stats()).rejects.toThrow(
+      "must include result or error",
+    );
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,580 @@
+export const AGENC_DAEMON_JSON_RPC_VERSION = "2.0" as const;
+
+export type AgenCDaemonRequestId = string | number;
+export type AgenCDaemonJsonPrimitive = string | number | boolean | null;
+export type AgenCDaemonJsonValue =
+  | AgenCDaemonJsonPrimitive
+  | readonly AgenCDaemonJsonValue[]
+  | AgenCDaemonJsonObject;
+
+export interface AgenCDaemonJsonObject {
+  readonly [key: string]: AgenCDaemonJsonValue | undefined;
+}
+
+export type AgenCDaemonMethod =
+  | "agent.create"
+  | "agent.list"
+  | "agent.attach"
+  | "agent.stop"
+  | "session.create"
+  | "session.list"
+  | "session.attach"
+  | "session.detach"
+  | "session.terminate"
+  | "message.send"
+  | "message.stream"
+  | "tool.approve"
+  | "tool.deny"
+  | "permission.list"
+  | "health.ping"
+  | "health.ready"
+  | "health.stats"
+  | "auth.login"
+  | "auth.whoami"
+  | "auth.logout";
+
+export interface AgentCreateParams extends AgenCDaemonJsonObject {
+  readonly cwd?: string;
+  readonly model?: string;
+  readonly provider?: string;
+  readonly profile?: string;
+  readonly instructions?: string;
+  readonly metadata?: AgenCDaemonJsonObject;
+}
+
+export interface AgentListParams extends AgenCDaemonJsonObject {
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+export interface AgentAttachParams extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly clientId?: string;
+}
+
+export interface AgentStopParams extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly reason?: string;
+}
+
+export interface SessionCreateParams extends AgenCDaemonJsonObject {
+  readonly agentId?: string;
+  readonly cwd?: string;
+  readonly initialPrompt?: string;
+  readonly metadata?: AgenCDaemonJsonObject;
+}
+
+export interface SessionListParams extends AgenCDaemonJsonObject {
+  readonly agentId?: string;
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+export interface SessionAttachParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly clientId?: string;
+}
+
+export interface SessionDetachParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly attachmentId?: string;
+  readonly clientId?: string;
+}
+
+export interface SessionTerminateParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly reason?: string;
+}
+
+export interface MessageContentBlock extends AgenCDaemonJsonObject {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export type MessageContent = string | readonly MessageContentBlock[];
+
+export interface MessageSendParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly content: MessageContent;
+  readonly clientMessageId?: string;
+  readonly metadata?: AgenCDaemonJsonObject;
+}
+
+export interface MessageStreamParams extends MessageSendParams {
+  readonly streamId?: string;
+}
+
+export interface ToolApproveParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly scope?: "once" | "session" | "agent";
+}
+
+export interface ToolDenyParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly reason?: string;
+}
+
+export interface PermissionListParams extends AgenCDaemonJsonObject {
+  readonly agentId?: string;
+  readonly sessionId?: string;
+}
+
+export type EmptyDaemonParams = Record<string, never>;
+
+export interface AgenCDaemonParamsByMethod {
+  readonly "agent.create": AgentCreateParams;
+  readonly "agent.list": AgentListParams;
+  readonly "agent.attach": AgentAttachParams;
+  readonly "agent.stop": AgentStopParams;
+  readonly "session.create": SessionCreateParams;
+  readonly "session.list": SessionListParams;
+  readonly "session.attach": SessionAttachParams;
+  readonly "session.detach": SessionDetachParams;
+  readonly "session.terminate": SessionTerminateParams;
+  readonly "message.send": MessageSendParams;
+  readonly "message.stream": MessageStreamParams;
+  readonly "tool.approve": ToolApproveParams;
+  readonly "tool.deny": ToolDenyParams;
+  readonly "permission.list": PermissionListParams;
+  readonly "health.ping": EmptyDaemonParams;
+  readonly "health.ready": EmptyDaemonParams;
+  readonly "health.stats": EmptyDaemonParams;
+  readonly "auth.login": EmptyDaemonParams;
+  readonly "auth.whoami": EmptyDaemonParams;
+  readonly "auth.logout": EmptyDaemonParams;
+}
+
+export type AgentStatus = "idle" | "running" | "stopping" | "stopped" | "error";
+export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
+
+export interface AgentSummary extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly status: AgentStatus;
+  readonly createdAt: string;
+  readonly cwd?: string;
+  readonly activeSessionIds?: readonly string[];
+  readonly metadata?: AgenCDaemonJsonObject;
+}
+
+export interface SessionSummary extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly agentId: string;
+  readonly status: SessionStatus;
+  readonly createdAt: string;
+  readonly cwd?: string;
+  readonly metadata?: AgenCDaemonJsonObject;
+  readonly activeAttachmentIds?: readonly string[];
+  readonly closedAt?: string;
+}
+
+export interface AgentCreateResult extends AgentSummary {
+  readonly sessionId?: string;
+}
+
+export interface AgentListResult extends AgenCDaemonJsonObject {
+  readonly agents: readonly AgentSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface AgentAttachResult extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly attachmentId: string;
+  readonly sessionIds: readonly string[];
+}
+
+export interface AgentStopResult extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly stopped: boolean;
+}
+
+export interface SessionCreateResult extends SessionSummary {}
+
+export interface SessionListResult extends AgenCDaemonJsonObject {
+  readonly sessions: readonly SessionSummary[];
+  readonly nextCursor?: string;
+}
+
+export interface SessionAttachResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly attachmentId: string;
+  readonly attachedAt: string;
+  readonly clientId?: string;
+  readonly activeAttachmentIds: readonly string[];
+}
+
+export interface SessionDetachResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly detached: boolean;
+  readonly attachmentId?: string;
+  readonly remainingAttachmentIds: readonly string[];
+}
+
+export interface SessionTerminateResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly terminated: boolean;
+  readonly status: "closed";
+  readonly closedAt: string;
+  readonly reason?: string;
+}
+
+export interface MessageSendResult extends AgenCDaemonJsonObject {
+  readonly messageId: string;
+  readonly acceptedAt: string;
+}
+
+export interface MessageStreamResult extends MessageSendResult {
+  readonly streamId: string;
+}
+
+export interface ToolDecisionResult extends AgenCDaemonJsonObject {
+  readonly requestId: string;
+  readonly decision: "approved" | "denied";
+}
+
+export interface PermissionGrant extends AgenCDaemonJsonObject {
+  readonly permissionId: string;
+  readonly subject: string;
+  readonly action: string;
+  readonly scope?: string;
+  readonly grantedAt?: string;
+  readonly expiresAt?: string;
+}
+
+export interface PermissionListResult extends AgenCDaemonJsonObject {
+  readonly permissions: readonly PermissionGrant[];
+}
+
+export interface HealthPingResult extends AgenCDaemonJsonObject {
+  readonly ok: true;
+  readonly now: string;
+}
+
+export interface HealthReadyResult extends AgenCDaemonJsonObject {
+  readonly ready: boolean;
+  readonly uptimeMs: number;
+  readonly now: string;
+}
+
+export interface HealthMemoryStats extends AgenCDaemonJsonObject {
+  readonly rss: number;
+  readonly heapTotal: number;
+  readonly heapUsed: number;
+  readonly external: number;
+  readonly arrayBuffers: number;
+}
+
+export interface HealthSessionStats extends AgenCDaemonJsonObject {
+  readonly active: number;
+  readonly closed: number;
+  readonly total: number;
+}
+
+export interface HealthStatsResult extends AgenCDaemonJsonObject {
+  readonly uptimeMs: number;
+  readonly now: string;
+  readonly sessions: HealthSessionStats;
+  readonly memory: HealthMemoryStats;
+}
+
+export interface AuthIdentity extends AgenCDaemonJsonObject {
+  readonly accountId?: string;
+  readonly email?: string;
+  readonly displayName?: string;
+  readonly plan?: string;
+}
+
+export interface AuthWhoamiResult extends AgenCDaemonJsonObject {
+  readonly authenticated: boolean;
+  readonly provider?: string;
+  readonly identity?: AuthIdentity;
+}
+
+export interface AuthLoginResult extends AgenCDaemonJsonObject {
+  readonly authenticated: true;
+  readonly provider?: string;
+  readonly identity?: AuthIdentity;
+}
+
+export interface AuthLogoutResult extends AgenCDaemonJsonObject {
+  readonly authenticated: false;
+}
+
+export interface AgenCDaemonResultByMethod {
+  readonly "agent.create": AgentCreateResult;
+  readonly "agent.list": AgentListResult;
+  readonly "agent.attach": AgentAttachResult;
+  readonly "agent.stop": AgentStopResult;
+  readonly "session.create": SessionCreateResult;
+  readonly "session.list": SessionListResult;
+  readonly "session.attach": SessionAttachResult;
+  readonly "session.detach": SessionDetachResult;
+  readonly "session.terminate": SessionTerminateResult;
+  readonly "message.send": MessageSendResult;
+  readonly "message.stream": MessageStreamResult;
+  readonly "tool.approve": ToolDecisionResult;
+  readonly "tool.deny": ToolDecisionResult;
+  readonly "permission.list": PermissionListResult;
+  readonly "health.ping": HealthPingResult;
+  readonly "health.ready": HealthReadyResult;
+  readonly "health.stats": HealthStatsResult;
+  readonly "auth.login": AuthLoginResult;
+  readonly "auth.whoami": AuthWhoamiResult;
+  readonly "auth.logout": AuthLogoutResult;
+}
+
+export interface AgenCDaemonRequest<
+  Method extends AgenCDaemonMethod = AgenCDaemonMethod,
+> {
+  readonly jsonrpc: typeof AGENC_DAEMON_JSON_RPC_VERSION;
+  readonly id: AgenCDaemonRequestId;
+  readonly method: Method;
+  readonly params?: AgenCDaemonParamsByMethod[Method];
+}
+
+export type AgenCDaemonErrorCode =
+  | -32700
+  | -32600
+  | -32601
+  | -32602
+  | -32603
+  | -32000;
+
+export interface AgenCDaemonErrorObject extends AgenCDaemonJsonObject {
+  readonly code: AgenCDaemonErrorCode;
+  readonly message: string;
+  readonly data?: AgenCDaemonJsonValue;
+}
+
+export interface AgenCDaemonSuccessResponse<
+  Method extends AgenCDaemonMethod = AgenCDaemonMethod,
+> {
+  readonly jsonrpc: typeof AGENC_DAEMON_JSON_RPC_VERSION;
+  readonly id: AgenCDaemonRequestId;
+  readonly result: AgenCDaemonResultByMethod[Method];
+}
+
+export interface AgenCDaemonErrorResponse {
+  readonly jsonrpc: typeof AGENC_DAEMON_JSON_RPC_VERSION;
+  readonly id: AgenCDaemonRequestId | null;
+  readonly error: AgenCDaemonErrorObject;
+}
+
+export type AgenCDaemonResponse<
+  Method extends AgenCDaemonMethod = AgenCDaemonMethod,
+> = AgenCDaemonSuccessResponse<Method> | AgenCDaemonErrorResponse;
+
+export interface AgenCDaemonTransport {
+  request<Method extends AgenCDaemonMethod>(
+    request: AgenCDaemonRequest<Method>,
+  ): Promise<AgenCDaemonResponse<Method>>;
+}
+
+export interface AgenCDaemonClientOptions {
+  readonly transport: AgenCDaemonTransport;
+  readonly createRequestId?: () => AgenCDaemonRequestId;
+}
+
+export class AgenCDaemonRpcError extends Error {
+  readonly code: AgenCDaemonErrorCode;
+  readonly data?: AgenCDaemonJsonValue;
+  readonly method: AgenCDaemonMethod;
+  readonly requestId: AgenCDaemonRequestId | null;
+
+  constructor(
+    error: AgenCDaemonErrorObject,
+    method: AgenCDaemonMethod,
+    requestId: AgenCDaemonRequestId | null,
+  ) {
+    super(error.message);
+    this.name = "AgenCDaemonRpcError";
+    this.code = error.code;
+    this.data = error.data;
+    this.method = method;
+    this.requestId = requestId;
+  }
+}
+
+export class AgenCDaemonMalformedResponseError extends Error {
+  readonly response: unknown;
+
+  constructor(message: string, response: unknown) {
+    super(message);
+    this.name = "AgenCDaemonMalformedResponseError";
+    this.response = response;
+  }
+}
+
+export class AgenCDaemonClient {
+  readonly #transport: AgenCDaemonTransport;
+  readonly #createRequestId: () => AgenCDaemonRequestId;
+
+  constructor(options: AgenCDaemonClientOptions) {
+    this.#transport = options.transport;
+    this.#createRequestId = options.createRequestId ?? createNumericIdFactory();
+  }
+
+  async request<Method extends AgenCDaemonMethod>(
+    method: Method,
+    params?: AgenCDaemonParamsByMethod[Method],
+  ): Promise<AgenCDaemonResultByMethod[Method]> {
+    const id = this.#createRequestId();
+    const request: AgenCDaemonRequest<Method> =
+      params === undefined
+        ? { jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION, id, method }
+        : { jsonrpc: AGENC_DAEMON_JSON_RPC_VERSION, id, method, params };
+    const response = await this.#transport.request(request);
+    return parseAgenCDaemonResponse(response, method, id);
+  }
+
+  createAgent(params: AgentCreateParams = {}): Promise<AgentCreateResult> {
+    return this.request("agent.create", params);
+  }
+
+  listAgents(params: AgentListParams = {}): Promise<AgentListResult> {
+    return this.request("agent.list", params);
+  }
+
+  attachAgent(params: AgentAttachParams): Promise<AgentAttachResult> {
+    return this.request("agent.attach", params);
+  }
+
+  stopAgent(params: AgentStopParams): Promise<AgentStopResult> {
+    return this.request("agent.stop", params);
+  }
+
+  createSession(
+    params: SessionCreateParams = {},
+  ): Promise<SessionCreateResult> {
+    return this.request("session.create", params);
+  }
+
+  listSessions(params: SessionListParams = {}): Promise<SessionListResult> {
+    return this.request("session.list", params);
+  }
+
+  attachSession(params: SessionAttachParams): Promise<SessionAttachResult> {
+    return this.request("session.attach", params);
+  }
+
+  detachSession(params: SessionDetachParams): Promise<SessionDetachResult> {
+    return this.request("session.detach", params);
+  }
+
+  terminateSession(
+    params: SessionTerminateParams,
+  ): Promise<SessionTerminateResult> {
+    return this.request("session.terminate", params);
+  }
+
+  sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
+    return this.request("message.send", params);
+  }
+
+  streamMessage(params: MessageStreamParams): Promise<MessageStreamResult> {
+    return this.request("message.stream", params);
+  }
+
+  approveTool(params: ToolApproveParams): Promise<ToolDecisionResult> {
+    return this.request("tool.approve", params);
+  }
+
+  denyTool(params: ToolDenyParams): Promise<ToolDecisionResult> {
+    return this.request("tool.deny", params);
+  }
+
+  listPermissions(
+    params: PermissionListParams = {},
+  ): Promise<PermissionListResult> {
+    return this.request("permission.list", params);
+  }
+
+  ping(): Promise<HealthPingResult> {
+    return this.request("health.ping");
+  }
+
+  ready(): Promise<HealthReadyResult> {
+    return this.request("health.ready");
+  }
+
+  stats(): Promise<HealthStatsResult> {
+    return this.request("health.stats");
+  }
+
+  login(): Promise<AuthLoginResult> {
+    return this.request("auth.login");
+  }
+
+  whoami(): Promise<AuthWhoamiResult> {
+    return this.request("auth.whoami");
+  }
+
+  logout(): Promise<AuthLogoutResult> {
+    return this.request("auth.logout");
+  }
+}
+
+export function createAgenCDaemonClient(
+  options: AgenCDaemonClientOptions,
+): AgenCDaemonClient {
+  return new AgenCDaemonClient(options);
+}
+
+function createNumericIdFactory(): () => number {
+  let nextId = 1;
+  return () => {
+    const id = nextId;
+    nextId += 1;
+    return id;
+  };
+}
+
+function parseAgenCDaemonResponse<Method extends AgenCDaemonMethod>(
+  response: AgenCDaemonResponse<Method>,
+  method: Method,
+  requestId: AgenCDaemonRequestId,
+): AgenCDaemonResultByMethod[Method] {
+  if (!isObjectRecord(response)) {
+    throw new AgenCDaemonMalformedResponseError(
+      "AgenC daemon response must be an object",
+      response,
+    );
+  }
+  if (response.jsonrpc !== AGENC_DAEMON_JSON_RPC_VERSION) {
+    throw new AgenCDaemonMalformedResponseError(
+      "AgenC daemon response used an unsupported JSON-RPC version",
+      response,
+    );
+  }
+  if (response.id !== requestId) {
+    throw new AgenCDaemonMalformedResponseError(
+      "AgenC daemon response id mismatch",
+      response,
+    );
+  }
+  if (isAgenCDaemonErrorResponse(response)) {
+    throw new AgenCDaemonRpcError(response.error, method, response.id);
+  }
+  if (!("result" in response)) {
+    throw new AgenCDaemonMalformedResponseError(
+      "AgenC daemon response must include result or error",
+      response,
+    );
+  }
+  return response.result;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAgenCDaemonErrorResponse(
+  response: unknown,
+): response is AgenCDaemonErrorResponse {
+  return (
+    isObjectRecord(response) &&
+    "error" in response &&
+    isObjectRecord(response.error)
+  );
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -26,6 +26,7 @@ export type AgenCDaemonMethod =
   | "session.terminate"
   | "session.clear"
   | "session.snapshot"
+  | "session.transcript"
   | "session.cancelTurn"
   | "session.mcp.addServer"
   | "message.send"
@@ -148,6 +149,10 @@ export interface SessionClearParams extends AgenCDaemonJsonObject {
 }
 
 export interface SessionSnapshotParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionTranscriptParams extends AgenCDaemonJsonObject {
   readonly sessionId: string;
 }
 
@@ -357,6 +362,7 @@ export interface AgenCDaemonParamsByMethod {
   readonly "session.terminate": SessionTerminateParams;
   readonly "session.clear": SessionClearParams;
   readonly "session.snapshot": SessionSnapshotParams;
+  readonly "session.transcript": SessionTranscriptParams;
   readonly "session.cancelTurn": SessionCancelTurnParams;
   readonly "session.mcp.addServer": SessionMcpAddServerParams;
   readonly "message.send": MessageSendParams;
@@ -532,6 +538,16 @@ export interface SessionSnapshotResult extends AgenCDaemonJsonObject {
     readonly cacheTotalInputTokens: number;
     readonly hitRate: number | null;
   };
+}
+
+export interface SessionTranscriptMessage extends AgenCDaemonJsonObject {
+  readonly role: string;
+  readonly text: string;
+}
+
+export interface SessionTranscriptResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly messages: readonly SessionTranscriptMessage[];
 }
 
 export interface SessionCancelTurnResult extends AgenCDaemonJsonObject {
@@ -831,6 +847,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.terminate": SessionTerminateResult;
   readonly "session.clear": SessionClearResult;
   readonly "session.snapshot": SessionSnapshotResult;
+  readonly "session.transcript": SessionTranscriptResult;
   readonly "session.cancelTurn": SessionCancelTurnResult;
   readonly "session.mcp.addServer": SessionMcpAddServerResult;
   readonly "message.send": MessageSendResult;
@@ -1023,6 +1040,12 @@ export class AgenCDaemonClient {
     params: SessionSnapshotParams,
   ): Promise<SessionSnapshotResult> {
     return this.request("session.snapshot", params);
+  }
+
+  transcriptSession(
+    params: SessionTranscriptParams,
+  ): Promise<SessionTranscriptResult> {
+    return this.request("session.transcript", params);
   }
 
   cancelSessionTurn(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -13,10 +13,12 @@ export interface AgenCDaemonJsonObject {
 
 export type AgenCDaemonMethod =
   | "initialize"
+  | "request.cancel"
   | "agent.create"
   | "agent.list"
   | "agent.attach"
   | "agent.stop"
+  | "agent.logs"
   | "session.create"
   | "session.list"
   | "session.attach"
@@ -26,7 +28,14 @@ export type AgenCDaemonMethod =
   | "message.stream"
   | "tool.approve"
   | "tool.deny"
+  | "tool.cancel"
+  | "elicitation.respond"
   | "permission.list"
+  | "fs.fuzzy_search"
+  | "commandExec.start"
+  | "commandExec.write"
+  | "commandExec.resize"
+  | "commandExec.terminate"
   | "health.ping"
   | "health.ready"
   | "health.stats"
@@ -34,11 +43,26 @@ export type AgenCDaemonMethod =
   | "auth.whoami"
   | "auth.logout";
 
+export type AgenCDaemonNotificationMethod =
+  | "commandExec.outputDelta"
+  | "event.message_chunk"
+  | "event.tool_request"
+  | "event.permission_request"
+  | "event.user_input_request"
+  | "event.mcp_elicitation_request"
+  | "event.agent_status"
+  | "event.session_event";
+
 export interface InitializeParams extends AgenCDaemonJsonObject {
   readonly protocolVersion?: string;
   readonly clientName?: string;
   readonly authCookie?: string;
   readonly capabilities?: AgenCDaemonJsonObject;
+}
+
+export interface RequestCancelParams extends AgenCDaemonJsonObject {
+  readonly requestId: AgenCDaemonRequestId;
+  readonly reason?: string;
 }
 
 export interface AgentCreateParams extends AgenCDaemonJsonObject {
@@ -66,6 +90,10 @@ export interface AgentAttachParams extends AgenCDaemonJsonObject {
 export interface AgentStopParams extends AgenCDaemonJsonObject {
   readonly agentId: string;
   readonly reason?: string;
+}
+
+export interface AgentLogsParams extends AgenCDaemonJsonObject {
+  readonly agentId: string;
 }
 
 export interface SessionCreateParams extends AgenCDaemonJsonObject {
@@ -127,19 +155,80 @@ export interface ToolDenyParams extends AgenCDaemonJsonObject {
   readonly reason?: string;
 }
 
+export interface ToolCancelParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly reason?: string;
+}
+
+export interface ElicitationRespondParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly requestId: AgenCDaemonRequestId;
+  readonly kind: "request_user_input" | "mcp";
+  readonly serverName?: string;
+  readonly response: AgenCDaemonJsonObject;
+}
+
 export interface PermissionListParams extends AgenCDaemonJsonObject {
   readonly agentId?: string;
   readonly sessionId?: string;
+}
+
+export interface FuzzyFileSearchParams extends AgenCDaemonJsonObject {
+  readonly query: string;
+  readonly roots: readonly string[];
+  readonly cancellationToken?: string | null;
+}
+
+export interface CommandExecTerminalSize extends AgenCDaemonJsonObject {
+  readonly rows: number;
+  readonly cols: number;
+}
+
+export type CommandExecEnv = Readonly<Record<string, string | null>>;
+
+export interface CommandExecStartParams extends AgenCDaemonJsonObject {
+  readonly command: readonly string[];
+  readonly processId?: string | null;
+  readonly tty?: boolean;
+  readonly streamStdin?: boolean;
+  readonly streamStdoutStderr?: boolean;
+  readonly outputBytesCap?: number | null;
+  readonly disableOutputCap?: boolean;
+  readonly disableTimeout?: boolean;
+  readonly timeoutMs?: number | null;
+  readonly cwd?: string | null;
+  readonly env?: CommandExecEnv | null;
+  readonly size?: CommandExecTerminalSize | null;
+  readonly sandboxPolicy?: AgenCDaemonJsonObject | null;
+  readonly permissionProfile?: AgenCDaemonJsonObject | null;
+}
+
+export interface CommandExecWriteParams extends AgenCDaemonJsonObject {
+  readonly processId: string;
+  readonly deltaBase64?: string | null;
+  readonly closeStdin?: boolean;
+}
+
+export interface CommandExecTerminateParams extends AgenCDaemonJsonObject {
+  readonly processId: string;
+}
+
+export interface CommandExecResizeParams extends AgenCDaemonJsonObject {
+  readonly processId: string;
+  readonly size: CommandExecTerminalSize;
 }
 
 export type EmptyDaemonParams = Record<string, never>;
 
 export interface AgenCDaemonParamsByMethod {
   readonly initialize: InitializeParams;
+  readonly "request.cancel": RequestCancelParams;
   readonly "agent.create": AgentCreateParams;
   readonly "agent.list": AgentListParams;
   readonly "agent.attach": AgentAttachParams;
   readonly "agent.stop": AgentStopParams;
+  readonly "agent.logs": AgentLogsParams;
   readonly "session.create": SessionCreateParams;
   readonly "session.list": SessionListParams;
   readonly "session.attach": SessionAttachParams;
@@ -149,7 +238,14 @@ export interface AgenCDaemonParamsByMethod {
   readonly "message.stream": MessageStreamParams;
   readonly "tool.approve": ToolApproveParams;
   readonly "tool.deny": ToolDenyParams;
+  readonly "tool.cancel": ToolCancelParams;
+  readonly "elicitation.respond": ElicitationRespondParams;
   readonly "permission.list": PermissionListParams;
+  readonly "fs.fuzzy_search": FuzzyFileSearchParams;
+  readonly "commandExec.start": CommandExecStartParams;
+  readonly "commandExec.write": CommandExecWriteParams;
+  readonly "commandExec.resize": CommandExecResizeParams;
+  readonly "commandExec.terminate": CommandExecTerminateParams;
   readonly "health.ping": EmptyDaemonParams;
   readonly "health.ready": EmptyDaemonParams;
   readonly "health.stats": EmptyDaemonParams;
@@ -159,6 +255,16 @@ export interface AgenCDaemonParamsByMethod {
 }
 
 export type AgentStatus = "idle" | "running" | "stopping" | "stopped" | "error";
+export type AgentRunStatus =
+  | "pending"
+  | "running"
+  | "working"
+  | "paused"
+  | "blocked"
+  | "suspended"
+  | "completed"
+  | "errored"
+  | "stopped";
 export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
 
 export interface AgentSummary extends AgenCDaemonJsonObject {
@@ -205,10 +311,42 @@ export interface AgentStopResult extends AgenCDaemonJsonObject {
   readonly stopped: boolean;
 }
 
+export interface AgentLogSession extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly itemCount: number;
+  readonly transcript: string;
+  readonly rolloutPath?: string;
+  readonly source?: string;
+}
+
+export interface AgentToolOutputLog extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly status: string;
+  readonly output: string;
+  readonly outputBytes: number;
+  readonly outputLogPath?: string;
+  readonly outputLogBytes?: number;
+}
+
+export interface AgentLogsResult extends AgenCDaemonJsonObject {
+  readonly agentId: string;
+  readonly transcript: string;
+  readonly sessions: readonly AgentLogSession[];
+  readonly toolOutputs?: readonly AgentToolOutputLog[];
+}
+
 export interface InitializeResult extends AgenCDaemonJsonObject {
   readonly type: "initialized";
   readonly protocolVersion: string;
   readonly capabilities: AgenCDaemonJsonObject;
+}
+
+export interface RequestCancelResult extends AgenCDaemonJsonObject {
+  readonly requestId: AgenCDaemonRequestId;
+  readonly cancelled: boolean;
+  readonly reason?: string;
 }
 
 export interface SessionCreateResult extends SessionSummary {}
@@ -252,7 +390,12 @@ export interface MessageStreamResult extends MessageSendResult {
 
 export interface ToolDecisionResult extends AgenCDaemonJsonObject {
   readonly requestId: string;
-  readonly decision: "approved" | "denied";
+  readonly decision: "approved" | "denied" | "cancelled";
+}
+
+export interface ElicitationRespondResult extends AgenCDaemonJsonObject {
+  readonly requestId: AgenCDaemonRequestId;
+  readonly resolved: boolean;
 }
 
 export interface PermissionGrant extends AgenCDaemonJsonObject {
@@ -266,6 +409,118 @@ export interface PermissionGrant extends AgenCDaemonJsonObject {
 
 export interface PermissionListResult extends AgenCDaemonJsonObject {
   readonly permissions: readonly PermissionGrant[];
+}
+
+export interface FuzzyFileSearchResult extends AgenCDaemonJsonObject {
+  readonly root: string;
+  readonly path: string;
+  readonly match_type: "file" | "directory";
+  readonly file_name: string;
+  readonly score: number;
+  readonly indices?: readonly number[];
+}
+
+export interface FuzzyFileSearchResponse extends AgenCDaemonJsonObject {
+  readonly files: readonly FuzzyFileSearchResult[];
+}
+
+export interface CommandExecResponse extends AgenCDaemonJsonObject {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface CommandExecWriteResponse extends AgenCDaemonJsonObject {}
+
+export interface CommandExecTerminateResponse extends AgenCDaemonJsonObject {}
+
+export interface CommandExecResizeResponse extends AgenCDaemonJsonObject {}
+
+export type CommandExecOutputStream = "stdout" | "stderr";
+
+export interface CommandExecOutputDeltaParams extends AgenCDaemonJsonObject {
+  readonly processId: string;
+  readonly stream: CommandExecOutputStream;
+  readonly deltaBase64: string;
+  readonly capReached: boolean;
+}
+
+export interface AgenCEventBaseParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly eventId: string;
+  readonly agentId?: string;
+  readonly sequence?: number;
+  readonly acceptedAt?: string;
+  readonly metadata?: AgenCDaemonJsonObject;
+}
+
+export interface EventMessageChunkParams extends AgenCEventBaseParams {
+  readonly messageId?: string;
+  readonly streamId?: string;
+  readonly delta: string;
+}
+
+export interface EventToolRequestParams extends AgenCEventBaseParams {
+  readonly requestId: string;
+  readonly toolName: string;
+  readonly turnId?: string;
+  readonly input?: AgenCDaemonJsonValue;
+  readonly recoveryCategory?: "idempotent" | "side-effecting" | "interactive";
+}
+
+export interface EventPermissionRequestParams extends AgenCEventBaseParams {
+  readonly requestId: string;
+  readonly toolName?: string;
+  readonly turnId?: string;
+  readonly permissions: readonly string[];
+  readonly input?: AgenCDaemonJsonValue;
+  readonly reason?: string;
+}
+
+export interface EventUserInputRequestParams extends AgenCEventBaseParams {
+  readonly requestId: string;
+  readonly callId: string;
+  readonly turnId: string;
+  readonly questions: readonly AgenCDaemonJsonObject[];
+}
+
+export interface EventMcpElicitationRequestParams
+  extends AgenCEventBaseParams {
+  readonly requestId: AgenCDaemonRequestId;
+  readonly serverName: string;
+  readonly turnId: string;
+  readonly request: AgenCDaemonJsonObject;
+}
+
+export interface EventAgentStatusParams extends AgenCEventBaseParams {
+  readonly agentId: string;
+  readonly status: AgentStatus;
+  readonly runStatus?: AgentRunStatus;
+  readonly turnId?: string;
+  readonly message?: string;
+}
+
+export interface EventSessionEventParams extends AgenCEventBaseParams {
+  readonly event: AgenCDaemonJsonObject;
+}
+
+export interface AgenCDaemonNotificationParamsByMethod {
+  readonly "commandExec.outputDelta": CommandExecOutputDeltaParams;
+  readonly "event.message_chunk": EventMessageChunkParams;
+  readonly "event.tool_request": EventToolRequestParams;
+  readonly "event.permission_request": EventPermissionRequestParams;
+  readonly "event.user_input_request": EventUserInputRequestParams;
+  readonly "event.mcp_elicitation_request": EventMcpElicitationRequestParams;
+  readonly "event.agent_status": EventAgentStatusParams;
+  readonly "event.session_event": EventSessionEventParams;
+}
+
+export interface AgenCDaemonNotification<
+  Method extends AgenCDaemonNotificationMethod = AgenCDaemonNotificationMethod,
+> {
+  readonly jsonrpc: typeof AGENC_DAEMON_JSON_RPC_VERSION;
+  readonly method: Method;
+  readonly params: AgenCDaemonNotificationParamsByMethod[Method];
 }
 
 export interface HealthPingResult extends AgenCDaemonJsonObject {
@@ -325,10 +580,12 @@ export interface AuthLogoutResult extends AgenCDaemonJsonObject {
 
 export interface AgenCDaemonResultByMethod {
   readonly initialize: InitializeResult;
+  readonly "request.cancel": RequestCancelResult;
   readonly "agent.create": AgentCreateResult;
   readonly "agent.list": AgentListResult;
   readonly "agent.attach": AgentAttachResult;
   readonly "agent.stop": AgentStopResult;
+  readonly "agent.logs": AgentLogsResult;
   readonly "session.create": SessionCreateResult;
   readonly "session.list": SessionListResult;
   readonly "session.attach": SessionAttachResult;
@@ -338,7 +595,14 @@ export interface AgenCDaemonResultByMethod {
   readonly "message.stream": MessageStreamResult;
   readonly "tool.approve": ToolDecisionResult;
   readonly "tool.deny": ToolDecisionResult;
+  readonly "tool.cancel": ToolDecisionResult;
+  readonly "elicitation.respond": ElicitationRespondResult;
   readonly "permission.list": PermissionListResult;
+  readonly "fs.fuzzy_search": FuzzyFileSearchResponse;
+  readonly "commandExec.start": CommandExecResponse;
+  readonly "commandExec.write": CommandExecWriteResponse;
+  readonly "commandExec.resize": CommandExecResizeResponse;
+  readonly "commandExec.terminate": CommandExecTerminateResponse;
   readonly "health.ping": HealthPingResult;
   readonly "health.ready": HealthReadyResult;
   readonly "health.stats": HealthStatsResult;
@@ -459,6 +723,10 @@ export class AgenCDaemonClient {
     return this.request("initialize", params);
   }
 
+  cancelRequest(params: RequestCancelParams): Promise<RequestCancelResult> {
+    return this.request("request.cancel", params);
+  }
+
   listAgents(params: AgentListParams = {}): Promise<AgentListResult> {
     return this.request("agent.list", params);
   }
@@ -469,6 +737,10 @@ export class AgenCDaemonClient {
 
   stopAgent(params: AgentStopParams): Promise<AgentStopResult> {
     return this.request("agent.stop", params);
+  }
+
+  getAgentLogs(params: AgentLogsParams): Promise<AgentLogsResult> {
+    return this.request("agent.logs", params);
   }
 
   createSession(
@@ -511,10 +783,46 @@ export class AgenCDaemonClient {
     return this.request("tool.deny", params);
   }
 
+  cancelTool(params: ToolCancelParams): Promise<ToolDecisionResult> {
+    return this.request("tool.cancel", params);
+  }
+
+  respondToElicitation(
+    params: ElicitationRespondParams,
+  ): Promise<ElicitationRespondResult> {
+    return this.request("elicitation.respond", params);
+  }
+
   listPermissions(
     params: PermissionListParams = {},
   ): Promise<PermissionListResult> {
     return this.request("permission.list", params);
+  }
+
+  fuzzySearch(params: FuzzyFileSearchParams): Promise<FuzzyFileSearchResponse> {
+    return this.request("fs.fuzzy_search", params);
+  }
+
+  startCommandExec(params: CommandExecStartParams): Promise<CommandExecResponse> {
+    return this.request("commandExec.start", params);
+  }
+
+  writeCommandExec(
+    params: CommandExecWriteParams,
+  ): Promise<CommandExecWriteResponse> {
+    return this.request("commandExec.write", params);
+  }
+
+  resizeCommandExec(
+    params: CommandExecResizeParams,
+  ): Promise<CommandExecResizeResponse> {
+    return this.request("commandExec.resize", params);
+  }
+
+  terminateCommandExec(
+    params: CommandExecTerminateParams,
+  ): Promise<CommandExecTerminateResponse> {
+    return this.request("commandExec.terminate", params);
   }
 
   ping(): Promise<HealthPingResult> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -12,6 +12,7 @@ export interface AgenCDaemonJsonObject {
 }
 
 export type AgenCDaemonMethod =
+  | "initialize"
   | "agent.create"
   | "agent.list"
   | "agent.attach"
@@ -33,12 +34,21 @@ export type AgenCDaemonMethod =
   | "auth.whoami"
   | "auth.logout";
 
+export interface InitializeParams extends AgenCDaemonJsonObject {
+  readonly protocolVersion?: string;
+  readonly clientName?: string;
+  readonly capabilities?: AgenCDaemonJsonObject;
+}
+
 export interface AgentCreateParams extends AgenCDaemonJsonObject {
+  readonly objective?: string;
   readonly cwd?: string;
   readonly model?: string;
   readonly provider?: string;
   readonly profile?: string;
   readonly instructions?: string;
+  readonly unattendedAllow?: readonly string[];
+  readonly unattendedDeny?: readonly string[];
   readonly metadata?: AgenCDaemonJsonObject;
 }
 
@@ -124,6 +134,7 @@ export interface PermissionListParams extends AgenCDaemonJsonObject {
 export type EmptyDaemonParams = Record<string, never>;
 
 export interface AgenCDaemonParamsByMethod {
+  readonly initialize: InitializeParams;
   readonly "agent.create": AgentCreateParams;
   readonly "agent.list": AgentListParams;
   readonly "agent.attach": AgentAttachParams;
@@ -151,8 +162,12 @@ export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
 
 export interface AgentSummary extends AgenCDaemonJsonObject {
   readonly agentId: string;
+  readonly agentPath?: string;
+  readonly objective?: string;
   readonly status: AgentStatus;
   readonly createdAt: string;
+  readonly startedAt?: string;
+  readonly lastActiveAt?: string;
   readonly cwd?: string;
   readonly activeSessionIds?: readonly string[];
   readonly metadata?: AgenCDaemonJsonObject;
@@ -187,6 +202,12 @@ export interface AgentAttachResult extends AgenCDaemonJsonObject {
 export interface AgentStopResult extends AgenCDaemonJsonObject {
   readonly agentId: string;
   readonly stopped: boolean;
+}
+
+export interface InitializeResult extends AgenCDaemonJsonObject {
+  readonly type: "initialized";
+  readonly protocolVersion: string;
+  readonly capabilities: AgenCDaemonJsonObject;
 }
 
 export interface SessionCreateResult extends SessionSummary {}
@@ -302,6 +323,7 @@ export interface AuthLogoutResult extends AgenCDaemonJsonObject {
 }
 
 export interface AgenCDaemonResultByMethod {
+  readonly initialize: InitializeResult;
   readonly "agent.create": AgentCreateResult;
   readonly "agent.list": AgentListResult;
   readonly "agent.attach": AgentAttachResult;
@@ -430,6 +452,10 @@ export class AgenCDaemonClient {
 
   createAgent(params: AgentCreateParams = {}): Promise<AgentCreateResult> {
     return this.request("agent.create", params);
+  }
+
+  initialize(params: InitializeParams = {}): Promise<InitializeResult> {
+    return this.request("initialize", params);
   }
 
   listAgents(params: AgentListParams = {}): Promise<AgentListResult> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -37,6 +37,7 @@ export type AgenCDaemonMethod =
 export interface InitializeParams extends AgenCDaemonJsonObject {
   readonly protocolVersion?: string;
   readonly clientName?: string;
+  readonly authCookie?: string;
   readonly capabilities?: AgenCDaemonJsonObject;
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -26,6 +26,11 @@ export type AgenCDaemonMethod =
   | "session.terminate"
   | "message.send"
   | "message.stream"
+  | "thread/realtime/start"
+  | "thread/realtime/appendAudio"
+  | "thread/realtime/appendText"
+  | "thread/realtime/stop"
+  | "thread/realtime/listVoices"
   | "tool.approve"
   | "tool.deny"
   | "tool.cancel"
@@ -51,7 +56,15 @@ export type AgenCDaemonNotificationMethod =
   | "event.user_input_request"
   | "event.mcp_elicitation_request"
   | "event.agent_status"
-  | "event.session_event";
+  | "event.session_event"
+  | "thread/realtime/started"
+  | "thread/realtime/itemAdded"
+  | "thread/realtime/transcript/delta"
+  | "thread/realtime/transcript/done"
+  | "thread/realtime/outputAudio/delta"
+  | "thread/realtime/sdp"
+  | "thread/realtime/error"
+  | "thread/realtime/closed";
 
 export interface InitializeParams extends AgenCDaemonJsonObject {
   readonly protocolVersion?: string;
@@ -141,6 +154,89 @@ export interface MessageSendParams extends AgenCDaemonJsonObject {
 
 export interface MessageStreamParams extends MessageSendParams {
   readonly streamId?: string;
+}
+
+export type ThreadRealtimeVersion = "v1" | "v2";
+export type ThreadRealtimeSessionMode = "conversational" | "transcription";
+export type ThreadRealtimeOutputModality = "audio" | "text";
+export type ThreadRealtimeTranscriptRole = "user" | "assistant";
+export type ThreadRealtimeClosedReason =
+  | "requested"
+  | "transport_closed"
+  | "error";
+export type ThreadRealtimeVoice =
+  | "alloy"
+  | "arbor"
+  | "ash"
+  | "ballad"
+  | "breeze"
+  | "cedar"
+  | "coral"
+  | "cove"
+  | "echo"
+  | "ember"
+  | "juniper"
+  | "maple"
+  | "marin"
+  | "sage"
+  | "shimmer"
+  | "sol"
+  | "spruce"
+  | "vale"
+  | "verse";
+
+export interface ThreadRealtimeWebsocketTransport extends AgenCDaemonJsonObject {
+  readonly type: "websocket";
+}
+
+export interface ThreadRealtimeWebrtcTransport extends AgenCDaemonJsonObject {
+  readonly type: "webrtc";
+  readonly sdp: string;
+}
+
+export type ThreadRealtimeStartTransport =
+  | ThreadRealtimeWebsocketTransport
+  | ThreadRealtimeWebrtcTransport;
+
+export interface ThreadRealtimeStartParams extends AgenCDaemonJsonObject {
+  readonly threadId: string;
+  readonly transport?: ThreadRealtimeStartTransport;
+  readonly realtimeSessionId?: string;
+  readonly prompt?: string | null;
+  readonly outputModality?: ThreadRealtimeOutputModality;
+  readonly voice?: ThreadRealtimeVoice | null;
+  readonly version?: ThreadRealtimeVersion;
+  readonly sessionMode?: ThreadRealtimeSessionMode;
+  readonly model?: string | null;
+}
+
+export interface ThreadRealtimeAudioChunk extends AgenCDaemonJsonObject {
+  readonly data: string;
+  readonly sampleRate: number;
+  readonly numChannels: number;
+  readonly samplesPerChannel?: number;
+  readonly itemId?: string;
+}
+
+export interface ThreadRealtimeAppendAudioParams extends AgenCDaemonJsonObject {
+  readonly threadId: string;
+  readonly audio: ThreadRealtimeAudioChunk;
+}
+
+export interface ThreadRealtimeAppendTextParams extends AgenCDaemonJsonObject {
+  readonly threadId: string;
+  readonly text: string;
+}
+
+export interface ThreadRealtimeStopParams extends AgenCDaemonJsonObject {
+  readonly threadId: string;
+}
+
+export interface ThreadRealtimeVoicesList extends AgenCDaemonJsonObject {
+  readonly v1: readonly ThreadRealtimeVoice[];
+  readonly v2: readonly ThreadRealtimeVoice[];
+  readonly defaultV1: ThreadRealtimeVoice;
+  readonly defaultV2: ThreadRealtimeVoice;
 }
 
 export interface ToolApproveParams extends AgenCDaemonJsonObject {
@@ -236,6 +332,11 @@ export interface AgenCDaemonParamsByMethod {
   readonly "session.terminate": SessionTerminateParams;
   readonly "message.send": MessageSendParams;
   readonly "message.stream": MessageStreamParams;
+  readonly "thread/realtime/start": ThreadRealtimeStartParams;
+  readonly "thread/realtime/appendAudio": ThreadRealtimeAppendAudioParams;
+  readonly "thread/realtime/appendText": ThreadRealtimeAppendTextParams;
+  readonly "thread/realtime/stop": ThreadRealtimeStopParams;
+  readonly "thread/realtime/listVoices": EmptyDaemonParams;
   readonly "tool.approve": ToolApproveParams;
   readonly "tool.deny": ToolDenyParams;
   readonly "tool.cancel": ToolCancelParams;
@@ -388,6 +489,20 @@ export interface MessageStreamResult extends MessageSendResult {
   readonly streamId: string;
 }
 
+export interface ThreadRealtimeStartResponse extends AgenCDaemonJsonObject {
+  readonly callId?: string;
+}
+
+export interface ThreadRealtimeAppendAudioResponse extends AgenCDaemonJsonObject {}
+
+export interface ThreadRealtimeAppendTextResponse extends AgenCDaemonJsonObject {}
+
+export interface ThreadRealtimeStopResponse extends AgenCDaemonJsonObject {}
+
+export interface ThreadRealtimeListVoicesResponse extends AgenCDaemonJsonObject {
+  readonly voices: ThreadRealtimeVoicesList;
+}
+
 export interface ToolDecisionResult extends AgenCDaemonJsonObject {
   readonly requestId: string;
   readonly decision: "approved" | "denied" | "cancelled";
@@ -484,8 +599,7 @@ export interface EventUserInputRequestParams extends AgenCEventBaseParams {
   readonly questions: readonly AgenCDaemonJsonObject[];
 }
 
-export interface EventMcpElicitationRequestParams
-  extends AgenCEventBaseParams {
+export interface EventMcpElicitationRequestParams extends AgenCEventBaseParams {
   readonly requestId: AgenCDaemonRequestId;
   readonly serverName: string;
   readonly turnId: string;
@@ -504,6 +618,45 @@ export interface EventSessionEventParams extends AgenCEventBaseParams {
   readonly event: AgenCDaemonJsonObject;
 }
 
+export interface ThreadRealtimeBaseParams extends AgenCDaemonJsonObject {
+  readonly threadId: string;
+}
+
+export interface ThreadRealtimeStartedParams extends ThreadRealtimeBaseParams {
+  readonly realtimeSessionId: string;
+  readonly version: ThreadRealtimeVersion;
+}
+
+export interface ThreadRealtimeItemAddedParams extends ThreadRealtimeBaseParams {
+  readonly item: AgenCDaemonJsonObject;
+}
+
+export interface ThreadRealtimeTranscriptDeltaParams extends ThreadRealtimeBaseParams {
+  readonly role: ThreadRealtimeTranscriptRole;
+  readonly delta: string;
+}
+
+export interface ThreadRealtimeTranscriptDoneParams extends ThreadRealtimeBaseParams {
+  readonly role: ThreadRealtimeTranscriptRole;
+  readonly text: string;
+}
+
+export interface ThreadRealtimeOutputAudioDeltaParams extends ThreadRealtimeBaseParams {
+  readonly audio: ThreadRealtimeAudioChunk;
+}
+
+export interface ThreadRealtimeSdpParams extends ThreadRealtimeBaseParams {
+  readonly sdp: string;
+}
+
+export interface ThreadRealtimeErrorParams extends ThreadRealtimeBaseParams {
+  readonly message: string;
+}
+
+export interface ThreadRealtimeClosedParams extends ThreadRealtimeBaseParams {
+  readonly reason: ThreadRealtimeClosedReason;
+}
+
 export interface AgenCDaemonNotificationParamsByMethod {
   readonly "commandExec.outputDelta": CommandExecOutputDeltaParams;
   readonly "event.message_chunk": EventMessageChunkParams;
@@ -513,6 +666,14 @@ export interface AgenCDaemonNotificationParamsByMethod {
   readonly "event.mcp_elicitation_request": EventMcpElicitationRequestParams;
   readonly "event.agent_status": EventAgentStatusParams;
   readonly "event.session_event": EventSessionEventParams;
+  readonly "thread/realtime/started": ThreadRealtimeStartedParams;
+  readonly "thread/realtime/itemAdded": ThreadRealtimeItemAddedParams;
+  readonly "thread/realtime/transcript/delta": ThreadRealtimeTranscriptDeltaParams;
+  readonly "thread/realtime/transcript/done": ThreadRealtimeTranscriptDoneParams;
+  readonly "thread/realtime/outputAudio/delta": ThreadRealtimeOutputAudioDeltaParams;
+  readonly "thread/realtime/sdp": ThreadRealtimeSdpParams;
+  readonly "thread/realtime/error": ThreadRealtimeErrorParams;
+  readonly "thread/realtime/closed": ThreadRealtimeClosedParams;
 }
 
 export interface AgenCDaemonNotification<
@@ -593,6 +754,11 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.terminate": SessionTerminateResult;
   readonly "message.send": MessageSendResult;
   readonly "message.stream": MessageStreamResult;
+  readonly "thread/realtime/start": ThreadRealtimeStartResponse;
+  readonly "thread/realtime/appendAudio": ThreadRealtimeAppendAudioResponse;
+  readonly "thread/realtime/appendText": ThreadRealtimeAppendTextResponse;
+  readonly "thread/realtime/stop": ThreadRealtimeStopResponse;
+  readonly "thread/realtime/listVoices": ThreadRealtimeListVoicesResponse;
   readonly "tool.approve": ToolDecisionResult;
   readonly "tool.deny": ToolDecisionResult;
   readonly "tool.cancel": ToolDecisionResult;
@@ -775,6 +941,34 @@ export class AgenCDaemonClient {
     return this.request("message.stream", params);
   }
 
+  startRealtime(
+    params: ThreadRealtimeStartParams,
+  ): Promise<ThreadRealtimeStartResponse> {
+    return this.request("thread/realtime/start", params);
+  }
+
+  appendRealtimeAudio(
+    params: ThreadRealtimeAppendAudioParams,
+  ): Promise<ThreadRealtimeAppendAudioResponse> {
+    return this.request("thread/realtime/appendAudio", params);
+  }
+
+  appendRealtimeText(
+    params: ThreadRealtimeAppendTextParams,
+  ): Promise<ThreadRealtimeAppendTextResponse> {
+    return this.request("thread/realtime/appendText", params);
+  }
+
+  stopRealtime(
+    params: ThreadRealtimeStopParams,
+  ): Promise<ThreadRealtimeStopResponse> {
+    return this.request("thread/realtime/stop", params);
+  }
+
+  listRealtimeVoices(): Promise<ThreadRealtimeListVoicesResponse> {
+    return this.request("thread/realtime/listVoices");
+  }
+
   approveTool(params: ToolApproveParams): Promise<ToolDecisionResult> {
     return this.request("tool.approve", params);
   }
@@ -803,7 +997,9 @@ export class AgenCDaemonClient {
     return this.request("fs.fuzzy_search", params);
   }
 
-  startCommandExec(params: CommandExecStartParams): Promise<CommandExecResponse> {
+  startCommandExec(
+    params: CommandExecStartParams,
+  ): Promise<CommandExecResponse> {
     return this.request("commandExec.start", params);
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -159,11 +159,6 @@ export interface MessageStreamParams extends MessageSendParams {
 export type ThreadRealtimeVersion = "v1" | "v2";
 export type ThreadRealtimeSessionMode = "conversational" | "transcription";
 export type ThreadRealtimeOutputModality = "audio" | "text";
-export type ThreadRealtimeTranscriptRole = "user" | "assistant";
-export type ThreadRealtimeClosedReason =
-  | "requested"
-  | "transport_closed"
-  | "error";
 export type ThreadRealtimeVoice =
   | "alloy"
   | "arbor"
@@ -200,14 +195,11 @@ export type ThreadRealtimeStartTransport =
 
 export interface ThreadRealtimeStartParams extends AgenCDaemonJsonObject {
   readonly threadId: string;
-  readonly transport?: ThreadRealtimeStartTransport;
-  readonly realtimeSessionId?: string;
+  readonly transport?: ThreadRealtimeStartTransport | null;
+  readonly realtimeSessionId?: string | null;
   readonly prompt?: string | null;
-  readonly outputModality?: ThreadRealtimeOutputModality;
+  readonly outputModality: ThreadRealtimeOutputModality;
   readonly voice?: ThreadRealtimeVoice | null;
-  readonly version?: ThreadRealtimeVersion;
-  readonly sessionMode?: ThreadRealtimeSessionMode;
-  readonly model?: string | null;
 }
 
 export interface ThreadRealtimeAudioChunk extends AgenCDaemonJsonObject {
@@ -489,9 +481,7 @@ export interface MessageStreamResult extends MessageSendResult {
   readonly streamId: string;
 }
 
-export interface ThreadRealtimeStartResponse extends AgenCDaemonJsonObject {
-  readonly callId?: string;
-}
+export interface ThreadRealtimeStartResponse extends AgenCDaemonJsonObject {}
 
 export interface ThreadRealtimeAppendAudioResponse extends AgenCDaemonJsonObject {}
 
@@ -623,21 +613,21 @@ export interface ThreadRealtimeBaseParams extends AgenCDaemonJsonObject {
 }
 
 export interface ThreadRealtimeStartedParams extends ThreadRealtimeBaseParams {
-  readonly realtimeSessionId: string;
+  readonly realtimeSessionId?: string | null;
   readonly version: ThreadRealtimeVersion;
 }
 
 export interface ThreadRealtimeItemAddedParams extends ThreadRealtimeBaseParams {
-  readonly item: AgenCDaemonJsonObject;
+  readonly item: AgenCDaemonJsonValue;
 }
 
 export interface ThreadRealtimeTranscriptDeltaParams extends ThreadRealtimeBaseParams {
-  readonly role: ThreadRealtimeTranscriptRole;
+  readonly role: string;
   readonly delta: string;
 }
 
 export interface ThreadRealtimeTranscriptDoneParams extends ThreadRealtimeBaseParams {
-  readonly role: ThreadRealtimeTranscriptRole;
+  readonly role: string;
   readonly text: string;
 }
 
@@ -654,7 +644,7 @@ export interface ThreadRealtimeErrorParams extends ThreadRealtimeBaseParams {
 }
 
 export interface ThreadRealtimeClosedParams extends ThreadRealtimeBaseParams {
-  readonly reason: ThreadRealtimeClosedReason;
+  readonly reason?: string | null;
 }
 
 export interface AgenCDaemonNotificationParamsByMethod {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,7 +24,10 @@ export type AgenCDaemonMethod =
   | "session.attach"
   | "session.detach"
   | "session.terminate"
+  | "session.clear"
+  | "session.snapshot"
   | "session.cancelTurn"
+  | "session.mcp.addServer"
   | "message.send"
   | "message.stream"
   | "thread/realtime/start"
@@ -45,6 +48,7 @@ export type AgenCDaemonMethod =
   | "health.ping"
   | "health.ready"
   | "health.stats"
+  | "daemon.reload"
   | "auth.login"
   | "auth.whoami"
   | "auth.logout";
@@ -139,9 +143,32 @@ export interface SessionTerminateParams extends AgenCDaemonJsonObject {
   readonly reason?: string;
 }
 
+export interface SessionClearParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+}
+
+export interface SessionSnapshotParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+}
+
 export interface SessionCancelTurnParams extends AgenCDaemonJsonObject {
   readonly sessionId: string;
   readonly reason?: string;
+}
+
+export interface SessionMcpServerConfig extends AgenCDaemonJsonObject {
+  readonly name: string;
+  readonly transport?: "stdio" | "sse" | "http" | "websocket" | "ws";
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly endpoint?: string;
+  readonly enabled?: boolean;
+  readonly required?: boolean;
+}
+
+export interface SessionMcpAddServerParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly config: SessionMcpServerConfig;
 }
 
 export interface MessageContentBlock extends AgenCDaemonJsonObject {
@@ -328,7 +355,10 @@ export interface AgenCDaemonParamsByMethod {
   readonly "session.attach": SessionAttachParams;
   readonly "session.detach": SessionDetachParams;
   readonly "session.terminate": SessionTerminateParams;
+  readonly "session.clear": SessionClearParams;
+  readonly "session.snapshot": SessionSnapshotParams;
   readonly "session.cancelTurn": SessionCancelTurnParams;
+  readonly "session.mcp.addServer": SessionMcpAddServerParams;
   readonly "message.send": MessageSendParams;
   readonly "message.stream": MessageStreamParams;
   readonly "thread/realtime/start": ThreadRealtimeStartParams;
@@ -349,6 +379,7 @@ export interface AgenCDaemonParamsByMethod {
   readonly "health.ping": EmptyDaemonParams;
   readonly "health.ready": EmptyDaemonParams;
   readonly "health.stats": EmptyDaemonParams;
+  readonly "daemon.reload": EmptyDaemonParams;
   readonly "auth.login": EmptyDaemonParams;
   readonly "auth.whoami": EmptyDaemonParams;
   readonly "auth.logout": EmptyDaemonParams;
@@ -479,10 +510,42 @@ export interface SessionTerminateResult extends AgenCDaemonJsonObject {
   readonly reason?: string;
 }
 
+export interface SessionClearResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly cleared: true;
+  readonly clearedAt: string;
+}
+
+export interface SessionSnapshotResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly turnCount: number;
+  readonly tokenUsage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+    readonly costUsd: number;
+  };
+  readonly cacheStats: {
+    readonly requestCount: number;
+    readonly cacheReadInputTokens: number;
+    readonly cacheCreationInputTokens: number;
+    readonly cacheTotalInputTokens: number;
+    readonly hitRate: number | null;
+  };
+}
+
 export interface SessionCancelTurnResult extends AgenCDaemonJsonObject {
   readonly sessionId: string;
   readonly cancelled: boolean;
   readonly reason?: string;
+}
+
+export interface SessionMcpAddServerResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly serverName: string;
+  readonly success: boolean;
+  readonly toolCount: number;
+  readonly error?: string;
 }
 
 export interface MessageSendResult extends AgenCDaemonJsonObject {
@@ -719,6 +782,17 @@ export interface HealthStatsResult extends AgenCDaemonJsonObject {
   readonly memory: HealthMemoryStats;
 }
 
+export interface DaemonReloadMcpServerResult extends AgenCDaemonJsonObject {
+  readonly status: "disabled" | "unsupported" | "listening";
+  readonly url?: string;
+}
+
+export interface DaemonReloadResult extends AgenCDaemonJsonObject {
+  readonly reloaded: true;
+  readonly configReloadedAt: string;
+  readonly mcpServer: DaemonReloadMcpServerResult;
+}
+
 export interface AuthIdentity extends AgenCDaemonJsonObject {
   readonly accountId?: string;
   readonly email?: string;
@@ -755,7 +829,10 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.attach": SessionAttachResult;
   readonly "session.detach": SessionDetachResult;
   readonly "session.terminate": SessionTerminateResult;
+  readonly "session.clear": SessionClearResult;
+  readonly "session.snapshot": SessionSnapshotResult;
   readonly "session.cancelTurn": SessionCancelTurnResult;
+  readonly "session.mcp.addServer": SessionMcpAddServerResult;
   readonly "message.send": MessageSendResult;
   readonly "message.stream": MessageStreamResult;
   readonly "thread/realtime/start": ThreadRealtimeStartResponse;
@@ -776,6 +853,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "health.ping": HealthPingResult;
   readonly "health.ready": HealthReadyResult;
   readonly "health.stats": HealthStatsResult;
+  readonly "daemon.reload": DaemonReloadResult;
   readonly "auth.login": AuthLoginResult;
   readonly "auth.whoami": AuthWhoamiResult;
   readonly "auth.logout": AuthLogoutResult;
@@ -937,6 +1015,28 @@ export class AgenCDaemonClient {
     return this.request("session.terminate", params);
   }
 
+  clearSession(params: SessionClearParams): Promise<SessionClearResult> {
+    return this.request("session.clear", params);
+  }
+
+  snapshotSession(
+    params: SessionSnapshotParams,
+  ): Promise<SessionSnapshotResult> {
+    return this.request("session.snapshot", params);
+  }
+
+  cancelSessionTurn(
+    params: SessionCancelTurnParams,
+  ): Promise<SessionCancelTurnResult> {
+    return this.request("session.cancelTurn", params);
+  }
+
+  addSessionMcpServer(
+    params: SessionMcpAddServerParams,
+  ): Promise<SessionMcpAddServerResult> {
+    return this.request("session.mcp.addServer", params);
+  }
+
   sendMessage(params: MessageSendParams): Promise<MessageSendResult> {
     return this.request("message.send", params);
   }
@@ -1035,6 +1135,10 @@ export class AgenCDaemonClient {
 
   stats(): Promise<HealthStatsResult> {
     return this.request("health.stats");
+  }
+
+  reloadDaemon(): Promise<DaemonReloadResult> {
+    return this.request("daemon.reload");
   }
 
   login(): Promise<AuthLoginResult> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -24,6 +24,7 @@ export type AgenCDaemonMethod =
   | "session.attach"
   | "session.detach"
   | "session.terminate"
+  | "session.cancelTurn"
   | "message.send"
   | "message.stream"
   | "thread/realtime/start"
@@ -134,6 +135,11 @@ export interface SessionDetachParams extends AgenCDaemonJsonObject {
 }
 
 export interface SessionTerminateParams extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly reason?: string;
+}
+
+export interface SessionCancelTurnParams extends AgenCDaemonJsonObject {
   readonly sessionId: string;
   readonly reason?: string;
 }
@@ -322,6 +328,7 @@ export interface AgenCDaemonParamsByMethod {
   readonly "session.attach": SessionAttachParams;
   readonly "session.detach": SessionDetachParams;
   readonly "session.terminate": SessionTerminateParams;
+  readonly "session.cancelTurn": SessionCancelTurnParams;
   readonly "message.send": MessageSendParams;
   readonly "message.stream": MessageStreamParams;
   readonly "thread/realtime/start": ThreadRealtimeStartParams;
@@ -469,6 +476,12 @@ export interface SessionTerminateResult extends AgenCDaemonJsonObject {
   readonly terminated: boolean;
   readonly status: "closed";
   readonly closedAt: string;
+  readonly reason?: string;
+}
+
+export interface SessionCancelTurnResult extends AgenCDaemonJsonObject {
+  readonly sessionId: string;
+  readonly cancelled: boolean;
   readonly reason?: string;
 }
 
@@ -742,6 +755,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.attach": SessionAttachResult;
   readonly "session.detach": SessionDetachResult;
   readonly "session.terminate": SessionTerminateResult;
+  readonly "session.cancelTurn": SessionCancelTurnResult;
   readonly "message.send": MessageSendResult;
   readonly "message.stream": MessageStreamResult;
   readonly "thread/realtime/start": ThreadRealtimeStartResponse;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@
  * - Private payload shape is seal/journal/image/binding/nullifier seeds
  */
 
+export * from "./daemon";
+
 export {
   generateProof,
   computeHashes,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const sourceUrl = (path: string): string =>
+  fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: "@tetsuo-ai/sdk/internal/spl-token",
+        replacement: sourceUrl("./src/spl-token.ts"),
+      },
+      {
+        find: "@tetsuo-ai/sdk",
+        replacement: sourceUrl("./src/index.ts"),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- publish the daemon JSON-RPC client surface in the SDK branch stack
- add the session.transcript method, params/result types, and client wrapper
- keep daemon method ordering aligned with agenc-core protocol contracts

## Test plan
- npm run typecheck
- npm run api:baseline:check
- agenc-core contract tests: npm --workspace=@tetsuo-ai/runtime run test -- tests/app-server/protocol.contract.test.ts tests/app-server/sdk-client.contract.test.ts tests/gaphunt3/mcp-client-resilient-client.test.ts