### PR TITLE
docs(sdk): reposition as the devnet ZK/privacy SDK (FD5/FD9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Repositioned the README and npm package description as the devnet-only ZK/privacy SDK, with a prominent pointer to `@tetsuo-ai/marketplace-sdk` (repo `tetsuo-ai/agenc-protocol`) for AgenC marketplace work. The mainnet privacy story is deferred, not hidden. No behavior changes.
+
 ### Added
 - Added initial changelog + API baseline tooling. (#983)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # @tetsuo-ai/sdk
 
-Privacy-preserving agent coordination on Solana.
+Devnet ZK/privacy SDK for AgenC — privacy-preserving agent coordination on Solana.
 
-This repo is the canonical public home for the AgenC SDK. It owns:
+> **Building on the AgenC marketplace?** Marketplace work — posting, claiming,
+> reviewing, and settling tasks on **mainnet** — lives in
+> [`@tetsuo-ai/marketplace-sdk`](https://www.npmjs.com/package/@tetsuo-ai/marketplace-sdk)
+> (repo: [tetsuo-ai/agenc-protocol](https://github.com/tetsuo-ai/agenc-protocol),
+> `packages/sdk-ts`). This package is **not** the marketplace SDK.
+
+## Scope: devnet-only ZK/privacy SDK
+
+This package targets the **devnet** deployment of the AgenC coordination
+program (`6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`) and its RISC Zero
+proof flows: private task completion, proof generation via the prover service,
+and the surrounding agent/dispute/governance helpers on that devnet program.
+
+The mainnet privacy story is deferred, not hidden: the ZK private-completion
+path has not shipped to the mainnet marketplace program yet, so nothing in this
+package signs or settles on mainnet. When private completion lands on mainnet,
+that support will be announced in this repo's changelog.
+
+This repo is the public home for the AgenC **devnet ZK/privacy SDK**. It owns:
 
 - the published `@tetsuo-ai/sdk` package
 - the public SDK changelog and release authority

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tetsuo-ai/sdk",
   "version": "1.4.0",
-  "description": "TypeScript SDK for AgenC - Privacy-preserving agent coordination on Solana",
+  "description": "Devnet ZK/privacy SDK for AgenC — privacy-preserving agent coordination on Solana (devnet program). For AgenC marketplace work use @tetsuo-ai/marketplace-sdk.",
   "packageManager": "npm@11.7.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## What

WP-D5 / FD5+FD9: the README claimed this repo is "the canonical public home for the AgenC SDK" while `@tetsuo-ai/sdk` is the devnet-only ZK/proof SDK (program `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`). Reposition honestly:

- Prominent pointer box at the top: marketplace work lives in `@tetsuo-ai/marketplace-sdk` (repo `tetsuo-ai/agenc-protocol`, `packages/sdk-ts`).
- New "Scope: devnet-only ZK/privacy SDK" section — states plainly that the mainnet privacy story is deferred, not hidden.
- npm `description` updated to match. **No npm publish** — the description rides the next release.
- CHANGELOG Unreleased entry.

## Gates

- `npm run typecheck` — clean
- `npm test` — 654/654 passed (48 files)

No behavior changes; docs + metadata only.

https://claude.ai/code/session_01PnpmjbFCZVQBB7w7DhypZY